### PR TITLE
feat: macOSアプリバンドル(.app)パッケージングの追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,20 @@ run: ## Run the application (KatanA)
 run-release: ## Run the application in release mode
 	cargo run --bin KatanA --release
 
+APP_NAME     := KatanA Desktop
+APP_BUNDLE   := target/release/bundle/osx/$(APP_NAME).app
+CONTENTS     := $(APP_BUNDLE)/Contents
+
+.PHONY: package-mac
+package-mac: ## Build macOS .app bundle (release)
+	cargo bundle --release --format osx --package katana-ui
+	@# Overlay project-specific Info.plist (cargo-bundle generates its own)
+	cp crates/katana-ui/Info.plist "$(CONTENTS)/Info.plist"
+	@# Copy icon into Resources/ (cargo-bundle does not handle icns correctly)
+	mkdir -p "$(CONTENTS)/Resources"
+	cp assets/icon.icns "$(CONTENTS)/Resources/icon.icns"
+	@echo "✅ $(APP_BUNDLE) created"
+
 # ---------- Formatters ----------
 
 .PHONY: fmt

--- a/crates/katana-ui/Cargo.toml
+++ b/crates/katana-ui/Cargo.toml
@@ -27,6 +27,14 @@ cc = "1"
 name = "KatanA"
 path = "src/main.rs"
 
+[package.metadata.bundle]
+name = "KatanA Desktop"
+identifier = "com.github.hiroyukifuruno.katana"
+icon = ["../../assets/icon.icns"]
+copyright = "Copyright © 2026 Hiroyuki Furuno"
+category = "public.app-category.developer-tools"
+short_description = "A fast, lightweight Markdown workspace for macOS"
+
 [dev-dependencies]
 egui_kittest = { version = "0.33", features = ["snapshot", "wgpu", "eframe"] }
 tempfile = "3"

--- a/crates/katana-ui/src/main.rs
+++ b/crates/katana-ui/src/main.rs
@@ -150,6 +150,7 @@ pub fn setup_fonts_from_preset(
     );
     ctx.set_fonts(fonts);
 
+    #[cfg(debug_assertions)]
     ctx.style_mut(|style| {
         style.debug.debug_on_hover = false;
         style.debug.show_expand_width = false;
@@ -164,6 +165,7 @@ pub fn setup_fonts_with_candidates(ctx: &egui::Context, candidates: &[&str]) {
     let fonts = build_font_definitions(candidates, &[]);
     ctx.set_fonts(fonts);
 
+    #[cfg(debug_assertions)]
     ctx.style_mut(|style| {
         style.debug.debug_on_hover = false;
         style.debug.show_expand_width = false;


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
macOS向け配布用アプリバンドル（`KatanA Desktop.app`）のパッケージング環境を構築する。

## 対応内容
- `cargo-bundle` を導入し、`[package.metadata.bundle]` セクションを `katana-ui/Cargo.toml` に追加
- `Makefile` に `make package-mac` ターゲットを追加（cargo bundle → Info.plist/icon.icns オーバーレイ）
- release ビルドでの `style.debug` コンパイルエラーを修正（`#[cfg(debug_assertions)]` ガード追加）

## 影響範囲
- `Makefile`: `package-mac` ターゲットの追加
- `crates/katana-ui/Cargo.toml`: `[package.metadata.bundle]` セクションの追加
- `crates/katana-ui/src/main.rs`: `style.debug` アクセスに cfg ガード追加

## 動作確認結果
- `make package-mac` で `KatanA Desktop.app` が正常に生成されることを確認
- `.app` 内に Info.plist、バイナリ（MacOS/KatanA）、アイコン（Resources/icon.icns）が正しく配置
- `make ci` が exit 0 で all pass（fmt-check + clippy + integration tests + coverage 100%）