### PR TITLE
feat: macOS DMGインストーラー生成の追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,37 @@ package-mac: ## Build macOS .app bundle (release)
 	cp assets/icon.icns "$(CONTENTS)/Resources/icon.icns"
 	@echo "✅ $(APP_BUNDLE) created"
 
+VERSION      := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+DMG_NAME     := KatanA-Desktop-$(VERSION).dmg
+DMG_OUT      := target/release/$(DMG_NAME)
+
+.PHONY: dmg
+dmg: package-mac ## Build macOS .dmg installer from .app bundle
+	@rm -f "$(DMG_OUT)"
+	@if command -v create-dmg >/dev/null 2>&1; then \
+		echo "Building DMG with create-dmg..."; \
+		create-dmg \
+			--volname "KatanA Desktop $(VERSION)" \
+			--window-pos 200 120 \
+			--window-size 600 400 \
+			--icon-size 100 \
+			--icon "KatanA Desktop.app" 150 190 \
+			--app-drop-link 450 190 \
+			--no-internet-enable \
+			"$(DMG_OUT)" \
+			"$(APP_BUNDLE)"; \
+	else \
+		echo "create-dmg not found, falling back to hdiutil..."; \
+		TMP_DMG=$$(mktemp -d)/staging; \
+		mkdir -p "$$TMP_DMG"; \
+		cp -R "$(APP_BUNDLE)" "$$TMP_DMG/"; \
+		ln -s /Applications "$$TMP_DMG/Applications"; \
+		hdiutil create -volname "KatanA Desktop $(VERSION)" \
+			-srcfolder "$$TMP_DMG" -ov -format UDZO "$(DMG_OUT)"; \
+		rm -rf "$$TMP_DMG"; \
+	fi
+	@echo "✅ $(DMG_OUT) created"
+
 # ---------- Formatters ----------
 
 .PHONY: fmt

--- a/crates/katana-ui/Info.plist
+++ b/crates/katana-ui/Info.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>CFBundleIdentifier</key>
     <string>com.github.hiroyukifuruno.katana</string>
+    <key>CFBundleExecutable</key>
+    <string>KatanA</string>
     <key>CFBundleName</key>
     <string>KatanA</string>
     <key>CFBundleDisplayName</key>
@@ -16,5 +18,7 @@
     <string>v0.0.1</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
 </dict>
 </plist>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,8 +12,10 @@
 #   - cargo-watch     : Auto-rebuild / auto-test on file changes
 #   - cargo-outdated  : Detect stale Cargo dependencies
 #   - cargo-bloat     : Analyse binary size (make bloat)
+#   - cargo-bundle    : macOS .app bundle packaging
 #   - tokei           : Count lines of source code (make loc)
 #   - lefthook        : Git hooks runner (pre-commit / pre-push)
+#   - create-dmg      : macOS .dmg installer builder
 #
 # =============================================================================
 
@@ -68,10 +70,12 @@ echo "    • cargo-llvm-cov  (coverage — pre-push gate: 100% line)"
 echo "    • cargo-watch     (make watch / make watch-run)"
 echo "    • cargo-outdated  (make outdated)"
 echo "    • cargo-bloat     (make bloat)"
+echo "    • cargo-bundle    (make package-mac)"
 echo ""
 echo "  ${BOLD}Development utilities${RESET}"
 echo "    • tokei           (make loc)"
 echo "    • lefthook        (Git hooks: pre-commit + pre-push)"
+echo "    • create-dmg      (make dmg)"
 echo ""
 
 if ! confirm "Proceed with the installation?"; then
@@ -209,6 +213,19 @@ else
 fi
 
 # =============================================================================
+# 8b. cargo-bundle
+# =============================================================================
+header "cargo-bundle"
+
+if cargo bundle --version &>/dev/null; then
+  success "cargo-bundle is already installed ($(cargo bundle --version))"
+else
+  info "Installing cargo-bundle..."
+  cargo install cargo-bundle
+  success "cargo-bundle installed"
+fi
+
+# =============================================================================
 # 9. tokei
 # =============================================================================
 header "tokei"
@@ -232,6 +249,19 @@ else
   info "Installing lefthook via Homebrew..."
   brew install lefthook
   success "lefthook installed ($(lefthook version))"
+fi
+
+# =============================================================================
+# 10b. create-dmg
+# =============================================================================
+header "create-dmg"
+
+if command -v create-dmg &>/dev/null; then
+  success "create-dmg is already installed ($(create-dmg --version 2>&1 | head -1))"
+else
+  info "Installing create-dmg via Homebrew..."
+  brew install create-dmg
+  success "create-dmg installed"
 fi
 
 # Install hooks into the repo (idempotent)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
macOS向け配布用DMGインストーラーの自動生成環境を構築する。

## 対応内容
- `Info.plist` に `CFBundleExecutable` キーを追加し、.app バンドルの起動エラーを解消
- `Makefile` に `make dmg` ターゲットを追加（create-dmg + hdiutil フォールバック）
- バージョン番号を `Cargo.toml` から動的取得し、DMGファイル名に含める
- `scripts/setup.sh` に `cargo-bundle` と `create-dmg` のインストール手順を追加

## 影響範囲
- `Makefile`: `dmg` ターゲットの追加（VERSION/DMG_NAME/DMG_OUT 変数）
- `crates/katana-ui/Info.plist`: `CFBundleExecutable` + `NSHighResolutionCapable` 追加
- `scripts/setup.sh`: `cargo-bundle` / `create-dmg` のインストールセクション追加

## 動作確認結果
- `make dmg` で `KatanA-Desktop-0.1.0.dmg` (6.5MB) が正常に生成
- DMGマウント後、`KatanA Desktop.app` と `Applications` リンクが確認済み
- `.app` の直接起動が正常に動作（CFBundleExecutable 修正後）
- `make ci` が exit 0 で all pass