### PR TITLE
feat: リリース自動化（git-cliff + make release）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,30 @@ dmg: package-mac ## Build macOS .dmg installer from .app bundle
 	fi
 	@echo "✅ $(DMG_OUT) created"
 
+# ---------- Release ----------
+
+.PHONY: release
+release: ## Create a versioned release (usage: make release VERSION=x.y.z)
+ifndef VERSION
+	$(error VERSION is required. Usage: make release VERSION=x.y.z)
+endif
+	@echo "🚀 Releasing v$(VERSION)..."
+	@# 1. Update workspace version in root Cargo.toml
+	sed -i '' 's/^version = ".*"/version = "$(VERSION)"/' Cargo.toml
+	@# 2. Update Info.plist version
+	sed -i '' '/<key>CFBundleShortVersionString<\/key>/{n;s|<string>.*</string>|<string>v$(VERSION)</string>|}' crates/katana-ui/Info.plist
+	@# 3. Generate/update CHANGELOG.md
+	git-cliff --tag "v$(VERSION)" --output CHANGELOG.md
+	@# 4. Stage and commit
+	git add Cargo.toml Cargo.lock crates/*/Cargo.toml crates/katana-ui/Info.plist CHANGELOG.md
+	git commit -m "chore: v$(VERSION) リリース準備"
+	@# 5. Create annotated tag
+	git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
+	@echo "✅ Release v$(VERSION) committed and tagged"
+	@echo "   Next steps:"
+	@echo "     make dmg                  # Build the DMG installer"
+	@echo "     git push && git push --tags  # Push to remote"
+
 # ---------- Formatters ----------
 
 .PHONY: fmt

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,53 @@
+# git-cliff configuration for KatanA
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+# Template for the changelog body
+header = """
+# Changelog\n
+All notable changes to KatanA Desktop will be documented in this file.\n
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/HiroyukiFuruno/katana
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+postprocessors = []
+
+[git]
+# Parse conventional commits
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "🚀 Features" },
+    { message = "^fix", group = "🐛 Bug Fixes" },
+    { message = "^docs", group = "📚 Documentation" },
+    { message = "^refactor", group = "♻️ Refactoring" },
+    { message = "^test", group = "🧪 Testing" },
+    { message = "^chore", group = "🔧 Miscellaneous" },
+    { message = "^perf", group = "⚡ Performance" },
+    { message = "^style", group = "🎨 Styling" },
+    { message = "^ci", group = "👷 CI/CD" },
+    { message = "^build", group = "📦 Build" },
+    { message = "^revert", group = "⏪ Reverted" },
+]
+protect_breaking_commits = false
+filter_commits = false
+topo_order = false
+sort_commits = "oldest"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -226,6 +226,19 @@ else
 fi
 
 # =============================================================================
+# 8c. git-cliff
+# =============================================================================
+header "git-cliff"
+
+if command -v git-cliff &>/dev/null; then
+  success "git-cliff is already installed ($(git-cliff --version))"
+else
+  info "Installing git-cliff..."
+  cargo install git-cliff
+  success "git-cliff installed"
+fi
+
+# =============================================================================
 # 9. tokei
 # =============================================================================
 header "tokei"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
バージョン管理とチェンジログ生成を自動化するリリースフローを構築する。

## 対応内容
- `git-cliff` を導入し、`cliff.toml` 設定ファイルを作成（Conventional Commits + 絵文字グループ分類）
- `Makefile` に `make release VERSION=x.y.z` ターゲットを追加
  - Cargo.toml のバージョン書き換え（sed）
  - Info.plist の CFBundleShortVersionString 連動更新
  - git-cliff による CHANGELOG.md 自動生成
  - git commit + annotated tag の作成
- `scripts/setup.sh` に `git-cliff` のインストールを追加

## 影響範囲
- `cliff.toml`: 新規追加
- `Makefile`: `release` ターゲットの追加
- `scripts/setup.sh`: `git-cliff` インストールセクション追加

## 動作確認結果
- `git-cliff --tag v0.0.1` でファーストリリース用チェンジログが全コミット履歴を含めて正常生成
- `make ci` が exit 0 で all pass