### PR TITLE
feat(ui): ワークスペース永続化・タブ復元ロジックの追加 (Task 1)

### DIFF
--- a/crates/katana-platform/src/settings.rs
+++ b/crates/katana-platform/src/settings.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 pub mod migration;
 pub mod migration_0_1_2;
 pub mod migration_0_1_3_to_0_1_4;
+pub mod migration_0_1_4_to_0_2_0;
 use migration::MigrationRunner;
 
 /// Split direction for editor/preview layout.
@@ -54,12 +55,10 @@ pub struct AppSettings {
     #[serde(default)]
     pub layout: LayoutSettings,
 
-    /// ID of the last opened workspace root path, restored on next launch.
+    /// Workspace settings (nesting).
     #[serde(default)]
-    pub last_workspace: Option<String>,
-    /// Workspace directory paths.
-    #[serde(default)]
-    pub workspace_paths: Vec<String>,
+    pub workspace: WorkspaceSettings,
+
     /// Terms of service accepted version (None = not accepted).
     #[serde(default)]
     pub terms_accepted_version: Option<String>,
@@ -124,8 +123,24 @@ pub struct LayoutSettings {
     pub toc_visible: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkspaceSettings {
+    /// ID of the last opened workspace root path, restored on next launch.
+    #[serde(default)]
+    pub last_workspace: Option<String>,
+    /// Workspace directory paths.
+    #[serde(default)]
+    pub paths: Vec<String>,
+    /// Previously opened document tabs.
+    #[serde(default)]
+    pub open_tabs: Vec<String>,
+    /// Index of the actively selected tab.
+    #[serde(default)]
+    pub active_tab_idx: Option<usize>,
+}
+
 fn default_version() -> String {
-    "0.1.4".to_string()
+    "0.2.0".to_string()
 }
 
 fn default_theme() -> String {
@@ -168,8 +183,7 @@ impl Default for AppSettings {
             theme: ThemeSettings::default(),
             font: FontSettings::default(),
             layout: LayoutSettings::default(),
-            last_workspace: None,
-            workspace_paths: Vec::new(),
+            workspace: WorkspaceSettings::default(),
             terms_accepted_version: None,
             language: default_language(),
             extra: Vec::new(),
@@ -256,6 +270,7 @@ impl SettingsRepository for JsonFileRepository {
                         let mut runner = MigrationRunner::new();
                         runner.add_strategy(Box::new(migration_0_1_2::Migration0_1_2));
                         runner.add_strategy(Box::new(migration_0_1_3_to_0_1_4::Migration013To014));
+                        runner.add_strategy(Box::new(migration_0_1_4_to_0_2_0::Migration014To020));
                         value = runner.migrate(value);
                         serde_json::from_value(value).unwrap_or_default()
                     }
@@ -383,7 +398,8 @@ mod tests {
         assert!((s.font.size - DEFAULT_FONT_SIZE).abs() < f32::EPSILON);
         assert_eq!(s.font.family, "monospace");
         assert_eq!(s.language, "en");
-        assert!(s.last_workspace.is_none());
+        assert!(s.workspace.last_workspace.is_none());
+        assert!(s.workspace.paths.is_empty());
     }
 
     #[test]

--- a/crates/katana-platform/src/settings/migration_0_1_4_to_0_2_0.rs
+++ b/crates/katana-platform/src/settings/migration_0_1_4_to_0_2_0.rs
@@ -1,0 +1,57 @@
+use crate::settings::migration::MigrationStrategy;
+use serde_json::{json, Value};
+
+/// Migrates settings from 0.1.4 to 0.2.0.
+///
+/// Changes:
+/// 1. Nests `last_workspace` and `workspace_paths` under `workspace`.
+/// 2. Initializes `open_tabs` and `active_tab_idx`.
+/// 3. Updates version to 0.2.0.
+pub struct Migration014To020;
+
+impl MigrationStrategy for Migration014To020 {
+    fn version(&self) -> &str {
+        "0.1.4"
+    }
+
+    fn migrate(&self, mut json: Value) -> Value {
+        if let Some(obj) = json.as_object_mut() {
+            let last_workspace = obj.remove("last_workspace").unwrap_or(Value::Null);
+            let workspace_paths = obj.remove("workspace_paths").unwrap_or(json!([]));
+
+            obj.insert(
+                "workspace".to_string(),
+                json!({
+                    "last_workspace": last_workspace,
+                    "paths": workspace_paths,
+                    "open_tabs": [],
+                    "active_tab_idx": Value::Null,
+                }),
+            );
+
+            obj.insert("version".to_string(), json!("0.2.0"));
+        }
+        json
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_migrate_from_0_1_4() {
+        let strategy = Migration014To020;
+        let old = json!({
+            "version": "0.1.4",
+            "last_workspace": "/path/to/ws",
+            "workspace_paths": ["/path/to/ws"]
+        });
+        let migrated = strategy.migrate(old);
+        assert_eq!(migrated["version"], "0.2.0");
+        assert_eq!(migrated["workspace"]["last_workspace"], "/path/to/ws");
+        assert_eq!(migrated["workspace"]["paths"][0], "/path/to/ws");
+        assert!(migrated.get("last_workspace").is_none());
+    }
+}

--- a/crates/katana-platform/tests/settings.rs
+++ b/crates/katana-platform/tests/settings.rs
@@ -4,7 +4,7 @@ use katana_platform::SettingsService;
 fn new_settings_service_has_defaults() {
     let svc = SettingsService::default();
     let settings = svc.settings();
-    assert!(settings.last_workspace.is_none());
+    assert!(settings.workspace.last_workspace.is_none());
     assert_eq!(settings.theme.theme, "dark");
     assert!(settings.extra.is_empty());
 }
@@ -20,7 +20,7 @@ fn settings_returns_immutable_reference() {
 #[test]
 fn settings_mut_allows_modification() {
     let mut svc = SettingsService::default();
-    svc.settings_mut().last_workspace = Some("/workspace".to_string());
+    svc.settings_mut().workspace.last_workspace = Some("/workspace".to_string());
     svc.settings_mut().theme.theme = "light".to_string();
     svc.settings_mut()
         .extra
@@ -30,7 +30,10 @@ fn settings_mut_allows_modification() {
         });
 
     let settings = svc.settings();
-    assert_eq!(settings.last_workspace.as_deref(), Some("/workspace"));
+    assert_eq!(
+        settings.workspace.last_workspace.as_deref(),
+        Some("/workspace")
+    );
     assert_eq!(settings.theme.theme, "light");
     assert_eq!(
         settings
@@ -48,8 +51,8 @@ fn default_trait_matches_new() {
     let from_new = SettingsService::new(Box::new(katana_platform::InMemoryRepository));
     // Both should produce equivalent default settings
     assert_eq!(
-        from_new.settings().last_workspace,
-        from_default.settings().last_workspace
+        from_new.settings().workspace.last_workspace,
+        from_default.settings().workspace.last_workspace
     );
     assert_eq!(
         from_new.settings().theme.theme,

--- a/crates/katana-ui/locales/de.json
+++ b/crates/katana-ui/locales/de.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "Kein Arbeitsbereich geöffnet.",
     "no_document_selected": "Kein Dokument geöffnet.",
-    "workspace_title": "Arbeitsbereich"
+    "workspace_title": "Arbeitsbereich",
+    "recent_workspaces": "Recent Workspaces"
   },
   "preview": {
     "preview_title": "Vorschau",
@@ -52,7 +53,8 @@
     "collapse_all": "Alle minimieren",
     "collapse_sidebar": "Seitenleiste ausblenden",
     "refresh_workspace": "Arbeitsbereich aktualisieren",
-    "toggle_filter": "フィルター切り替え"
+    "toggle_filter": "フィルター切り替え",
+    "remove_workspace": "Remove from history"
   },
   "ai": {
     "ai_unconfigured": "[AI: nicht konfiguriert]"

--- a/crates/katana-ui/locales/en.json
+++ b/crates/katana-ui/locales/en.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "No workspace open.",
     "no_document_selected": "No document open.",
-    "workspace_title": "Workspace"
+    "workspace_title": "Workspace",
+    "recent_workspaces": "Recent Workspaces"
   },
   "preview": {
     "preview_title": "Preview",
@@ -52,7 +53,8 @@
     "collapse_all": "Collapse all",
     "collapse_sidebar": "Hide Sidebar",
     "refresh_workspace": "Refresh workspace",
-    "toggle_filter": "Toggle filter"
+    "toggle_filter": "Toggle filter",
+    "remove_workspace": "Remove from history"
   },
   "ai": {
     "ai_unconfigured": "[AI: unconfigured]"

--- a/crates/katana-ui/locales/es.json
+++ b/crates/katana-ui/locales/es.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "Ningún espacio de trabajo abierto.",
     "no_document_selected": "Ningún documento abierto.",
-    "workspace_title": "Espacio de Trabajo"
+    "workspace_title": "Espacio de Trabajo",
+    "recent_workspaces": "Recent Workspaces"
   },
   "preview": {
     "preview_title": "Vista Previa",
@@ -52,7 +53,8 @@
     "collapse_all": "Contraer todo",
     "collapse_sidebar": "Ocultar la barra lateral",
     "refresh_workspace": "Actualizar espacio de trabajo",
-    "toggle_filter": "フィルター切り替え"
+    "toggle_filter": "フィルター切り替え",
+    "remove_workspace": "Remove from history"
   },
   "ai": {
     "ai_unconfigured": "[IA: no configurado]"

--- a/crates/katana-ui/locales/fr.json
+++ b/crates/katana-ui/locales/fr.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "Aucun espace de travail ouvert.",
     "no_document_selected": "Aucun document ouvert.",
-    "workspace_title": "Espace de travail"
+    "workspace_title": "Espace de travail",
+    "recent_workspaces": "Recent Workspaces"
   },
   "preview": {
     "preview_title": "Aperçu",
@@ -52,7 +53,8 @@
     "collapse_all": "Tout réduire",
     "collapse_sidebar": "Masquer la barre latérale",
     "refresh_workspace": "Actualiser l'espace de travail",
-    "toggle_filter": "フィルター切り替え"
+    "toggle_filter": "フィルター切り替え",
+    "remove_workspace": "Remove from history"
   },
   "ai": {
     "ai_unconfigured": "[AI : non configuré]"

--- a/crates/katana-ui/locales/it.json
+++ b/crates/katana-ui/locales/it.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "Nessuno spazio di lavoro aperto.",
     "no_document_selected": "Nessun documento aperto.",
-    "workspace_title": "Spazio di Lavoro"
+    "workspace_title": "Spazio di Lavoro",
+    "recent_workspaces": "Recent Workspaces"
   },
   "preview": {
     "preview_title": "Anteprima",
@@ -52,7 +53,8 @@
     "collapse_all": "Comprimi tutto",
     "collapse_sidebar": "Nascondi la barra laterale",
     "refresh_workspace": "Aggiorna lo spazio di lavoro",
-    "toggle_filter": "フィルター切り替え"
+    "toggle_filter": "フィルター切り替え",
+    "remove_workspace": "Remove from history"
   },
   "ai": {
     "ai_unconfigured": "[AI: non configurato]"

--- a/crates/katana-ui/locales/ja.json
+++ b/crates/katana-ui/locales/ja.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "ワークスペースが開かれていません。",
     "no_document_selected": "ドキュメントが開かれていません。",
-    "workspace_title": "ワークスペース"
+    "workspace_title": "ワークスペース",
+    "recent_workspaces": "最近のワークスペース"
   },
   "preview": {
     "preview_title": "プレビュー",
@@ -52,7 +53,8 @@
     "collapse_all": "すべて折りたたむ",
     "collapse_sidebar": "サイドバーを隠す",
     "refresh_workspace": "ワークスペースを更新",
-    "toggle_filter": "フィルター切り替え"
+    "toggle_filter": "フィルター切り替え",
+    "remove_workspace": "履歴から削除"
   },
   "ai": {
     "ai_unconfigured": "[AI: 未設定]"

--- a/crates/katana-ui/locales/ko.json
+++ b/crates/katana-ui/locales/ko.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "열린 워크스페이스가 없습니다.",
     "no_document_selected": "열린 문서가 없습니다.",
-    "workspace_title": "워크스페이스"
+    "workspace_title": "워크스페이스",
+    "recent_workspaces": "Recent Workspaces"
   },
   "preview": {
     "preview_title": "미리보기",
@@ -52,7 +53,8 @@
     "collapse_all": "모두 접기",
     "collapse_sidebar": "사이드바 숨기기",
     "refresh_workspace": "워크스페이스 새로고침",
-    "toggle_filter": "フィルター切り替え"
+    "toggle_filter": "フィルター切り替え",
+    "remove_workspace": "Remove from history"
   },
   "ai": {
     "ai_unconfigured": "[AI: 설정되지 않음]"

--- a/crates/katana-ui/locales/pt.json
+++ b/crates/katana-ui/locales/pt.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "Nenhum espaço de trabalho aberto.",
     "no_document_selected": "Nenhum documento aberto.",
-    "workspace_title": "Espaço de Trabalho"
+    "workspace_title": "Espaço de Trabalho",
+    "recent_workspaces": "Recent Workspaces"
   },
   "preview": {
     "preview_title": "Visualização",
@@ -52,7 +53,8 @@
     "collapse_all": "Recolher tudo",
     "collapse_sidebar": "Ocultar a Barra Lateral",
     "refresh_workspace": "Atualizar espaço de trabalho",
-    "toggle_filter": "フィルター切り替え"
+    "toggle_filter": "フィルター切り替え",
+    "remove_workspace": "Remove from history"
   },
   "ai": {
     "ai_unconfigured": "[AI: não configurado]"

--- a/crates/katana-ui/locales/zh-CN.json
+++ b/crates/katana-ui/locales/zh-CN.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "未打开工作区。",
     "no_document_selected": "未选择文档。",
-    "workspace_title": "工作区"
+    "workspace_title": "工作区",
+    "recent_workspaces": "Recent Workspaces"
   },
   "preview": {
     "preview_title": "预览",
@@ -52,7 +53,8 @@
     "collapse_all": "全部折叠",
     "collapse_sidebar": "隐藏侧边栏",
     "refresh_workspace": "刷新工作区",
-    "toggle_filter": "フィルター切り替え"
+    "toggle_filter": "フィルター切り替え",
+    "remove_workspace": "Remove from history"
   },
   "ai": {
     "ai_unconfigured": "[AI: 未配置]"

--- a/crates/katana-ui/locales/zh-TW.json
+++ b/crates/katana-ui/locales/zh-TW.json
@@ -9,7 +9,8 @@
   "workspace": {
     "no_workspace_open": "未開啟工作區。",
     "no_document_selected": "未選擇文件。",
-    "workspace_title": "工作区"
+    "workspace_title": "工作区",
+    "recent_workspaces": "Recent Workspaces"
   },
   "preview": {
     "preview_title": "預覽",
@@ -52,7 +53,8 @@
     "collapse_all": "全部摺疊",
     "collapse_sidebar": "隱藏側邊欄",
     "refresh_workspace": "刷新工作區",
-    "toggle_filter": "フィルター切り替え"
+    "toggle_filter": "フィルター切り替え",
+    "remove_workspace": "Remove from history"
   },
   "ai": {
     "ai_unconfigured": "[AI: 未配置]"

--- a/crates/katana-ui/src/app_state.rs
+++ b/crates/katana-ui/src/app_state.rs
@@ -58,6 +58,8 @@ pub enum AppAction {
     OpenWorkspace(std::path::PathBuf),
     /// Select a file in the project tree.
     SelectDocument(std::path::PathBuf),
+    /// Remove a workspace from the persistence list.
+    RemoveWorkspace(String),
     /// Close a tab.
     CloseDocument(usize),
     /// Update the buffer of the active document.

--- a/crates/katana-ui/src/i18n.rs
+++ b/crates/katana-ui/src/i18n.rs
@@ -46,6 +46,7 @@ pub struct WorkspaceMessages {
     pub no_workspace_open: String,
     pub no_document_selected: String,
     pub workspace_title: String,
+    pub recent_workspaces: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -110,6 +111,7 @@ pub struct ActionMessages {
     pub collapse_sidebar: String,
     pub refresh_workspace: String,
     pub toggle_filter: String,
+    pub remove_workspace: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/katana-ui/src/main.rs
+++ b/crates/katana-ui/src/main.rs
@@ -128,7 +128,7 @@ fn main() -> eframe::Result<()> {
 
     // Read saved values before moving settings into AppState.
     let saved_language = settings.settings().language.clone();
-    let saved_workspace = settings.settings().last_workspace.clone();
+    let saved_workspace = settings.settings().workspace.last_workspace.clone();
 
     let state = AppState::new(ai_registry, plugin_registry, settings);
 

--- a/crates/katana-ui/src/shell.rs
+++ b/crates/katana-ui/src/shell.rs
@@ -48,6 +48,12 @@ pub(crate) const TAB_TOOLTIP_SHOW_DELAY_SECS: f32 = 0.25;
 /// Spacing below the 'No workspace selected' display in the file tree (px).
 pub(crate) const NO_WORKSPACE_BOTTOM_SPACING: f32 = 8.0;
 
+/// Vertical spacing between the "recent workspaces" section and other elements (px).
+pub(crate) const RECENT_WORKSPACES_SPACING: f32 = 8.0;
+
+/// Vertical spacing between items in the "recent workspaces" section (px).
+pub(crate) const RECENT_WORKSPACES_ITEM_SPACING: f32 = 4.0;
+
 /// Polling interval for checking download completion (ms).
 pub(crate) const DOWNLOAD_STATUS_CHECK_INTERVAL_MS: u64 = 200;
 
@@ -165,10 +171,65 @@ impl KatanaApp {
                 self.state.open_documents.clear();
                 self.state.active_doc_idx = None;
                 self.state.filter_cache = None;
+                let path_str = path.display().to_string();
+                let is_same_as_last = self
+                    .state
+                    .settings
+                    .settings()
+                    .workspace
+                    .last_workspace
+                    .as_deref()
+                    == Some(path_str.as_str());
+
+                // Clone what we need so we don't hold the immutable borrow
+                let (mut to_open, active_idx) = if is_same_as_last {
+                    let settings = self.state.settings.settings();
+                    (
+                        settings.workspace.open_tabs.clone(),
+                        settings.workspace.active_tab_idx,
+                    )
+                } else {
+                    (Vec::new(), None)
+                };
 
                 // Persist the last opened workspace path.
-                self.state.settings.settings_mut().last_workspace =
-                    Some(path.display().to_string());
+                {
+                    let settings = self.state.settings.settings_mut();
+                    settings.workspace.last_workspace = Some(path_str.clone());
+                    if !settings.workspace.paths.contains(&path_str) {
+                        settings.workspace.paths.push(path_str);
+                    }
+                    if !is_same_as_last {
+                        settings.workspace.open_tabs.clear();
+                        settings.workspace.active_tab_idx = None;
+                    }
+                }
+
+                // If opening the same workspace as last time (e.g. startup), restore tabs
+                if is_same_as_last {
+                    // Retain only files that exist
+                    to_open.retain(|p| std::path::Path::new(p).exists());
+
+                    for p in &to_open {
+                        if let Ok(doc) = self.fs.load_document(std::path::PathBuf::from(p)) {
+                            self.state.open_documents.push(doc);
+                            self.state
+                                .initialize_tab_split_state(std::path::PathBuf::from(p));
+                        }
+                    }
+                    if !self.state.open_documents.is_empty() {
+                        let idx = active_idx
+                            .unwrap_or(0)
+                            .min(self.state.open_documents.len() - 1);
+                        self.state.active_doc_idx = Some(idx);
+                        let active_doc = &self.state.open_documents[idx];
+                        self.full_refresh_preview(
+                            &active_doc.path.clone(),
+                            &active_doc.buffer.clone(),
+                        );
+                    }
+                }
+
                 if let Err(e) = self.state.settings.save() {
                     tracing::warn!("Failed to save settings: {e}");
                 }
@@ -225,6 +286,7 @@ impl KatanaApp {
                 // Re-render only if the content has changed
                 self.full_refresh_preview(&path, &src);
             }
+            self.save_workspace_state();
             // No change -> reuse existing PreviewPane (cached)
             return;
         }
@@ -236,6 +298,7 @@ impl KatanaApp {
                 self.state.active_doc_idx = Some(self.state.open_documents.len() - 1);
                 self.state.initialize_tab_split_state(path.clone());
                 self.full_refresh_preview(&path, &src);
+                self.save_workspace_state();
             }
             Err(e) => {
                 let error = e.to_string();
@@ -244,6 +307,32 @@ impl KatanaApp {
                     &vec![("error", error.as_str())],
                 ));
             }
+        }
+    }
+
+    fn handle_remove_workspace(&mut self, path: String) {
+        let settings = self.state.settings.settings_mut();
+        settings.workspace.paths.retain(|p| p != &path);
+        // If the removed workspace matches the last_workspace, we don't necessarily clear last_workspace
+        // because it's still the active one, but it won't appear in the history list anymore.
+        if let Err(e) = self.state.settings.save() {
+            tracing::warn!("Failed to save settings after removing workspace: {e}");
+        }
+    }
+
+    fn save_workspace_state(&mut self) {
+        let open_tabs: Vec<String> = self
+            .state
+            .open_documents
+            .iter()
+            .map(|d| d.path.display().to_string())
+            .collect();
+        let idx = self.state.active_doc_idx;
+        let settings = self.state.settings.settings_mut();
+        settings.workspace.open_tabs = open_tabs;
+        settings.workspace.active_tab_idx = idx;
+        if let Err(e) = self.state.settings.save() {
+            tracing::warn!("Failed to save workspace tab state: {e}");
         }
     }
 
@@ -262,7 +351,10 @@ impl KatanaApp {
             return;
         };
         match self.fs.save_document(doc) {
-            Ok(()) => self.state.status_message = Some(crate::i18n::get().status.saved.clone()),
+            Ok(()) => {
+                self.state.status_message = Some(crate::i18n::get().status.saved.clone());
+                self.save_workspace_state();
+            }
             Err(e) => {
                 let error = e.to_string();
                 self.state.status_message = Some(crate::i18n::tf(
@@ -276,7 +368,9 @@ impl KatanaApp {
     pub(crate) fn process_action(&mut self, action: AppAction) {
         match action {
             AppAction::OpenWorkspace(p) => self.handle_open_workspace(p),
+            AppAction::RefreshWorkspace => self.handle_refresh_workspace(),
             AppAction::SelectDocument(p) => self.handle_select_document(p),
+            AppAction::RemoveWorkspace(path) => self.handle_remove_workspace(path),
             AppAction::CloseDocument(idx) => {
                 if idx < self.state.open_documents.len() {
                     self.state.open_documents.remove(idx);
@@ -286,6 +380,7 @@ impl KatanaApp {
                         Some(self.state.open_documents.len() - 1)
                     };
                 }
+                self.save_workspace_state();
             }
             AppAction::UpdateBuffer(c) => self.handle_update_buffer(c),
             AppAction::SaveDocument => self.handle_save_document(),
@@ -320,7 +415,6 @@ impl KatanaApp {
                 // Keep toolbar toggles temporary and scoped to the active tab.
                 self.state.set_active_pane_order(order);
             }
-            AppAction::RefreshWorkspace => self.handle_refresh_workspace(),
             AppAction::None => {}
         }
     }

--- a/crates/katana-ui/src/shell_ui.rs
+++ b/crates/katana-ui/src/shell_ui.rs
@@ -17,8 +17,9 @@ use crate::{
 
 use crate::shell::{
     ACTIVE_FILE_HIGHLIGHT_ROUNDING, EDITOR_INITIAL_VISIBLE_ROWS, FILE_TREE_PANEL_DEFAULT_WIDTH,
-    FILE_TREE_PANEL_MIN_WIDTH, NO_WORKSPACE_BOTTOM_SPACING, SCROLL_SYNC_DEAD_ZONE,
-    TAB_INTER_ITEM_SPACING, TAB_NAV_BUTTONS_AREA_WIDTH, TAB_TOOLTIP_SHOW_DELAY_SECS,
+    FILE_TREE_PANEL_MIN_WIDTH, NO_WORKSPACE_BOTTOM_SPACING, RECENT_WORKSPACES_ITEM_SPACING,
+    RECENT_WORKSPACES_SPACING, SCROLL_SYNC_DEAD_ZONE, TAB_INTER_ITEM_SPACING,
+    TAB_NAV_BUTTONS_AREA_WIDTH, TAB_TOOLTIP_SHOW_DELAY_SECS,
 };
 use crate::theme_bridge;
 use katana_platform::{PaneOrder, SplitDirection};
@@ -149,6 +150,32 @@ pub(crate) fn render_workspace_panel(
                         state.force_tree_open = Some(false);
                     }
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if !state.settings.settings().workspace.paths.is_empty() {
+                            ui.menu_button("📄", |ui| {
+                                for path in state.settings.settings().workspace.paths.iter().rev() {
+                                    ui.horizontal(|ui| {
+                                        if ui
+                                            .button("×")
+                                            .on_hover_text(
+                                                crate::i18n::get().action.remove_workspace.clone(),
+                                            )
+                                            .clicked()
+                                        {
+                                            *action = AppAction::RemoveWorkspace(path.clone());
+                                            ui.close();
+                                        }
+                                        if ui.selectable_label(false, path).clicked() {
+                                            *action = AppAction::OpenWorkspace(
+                                                std::path::PathBuf::from(path),
+                                            );
+                                            ui.close();
+                                        }
+                                    });
+                                }
+                            })
+                            .response
+                            .on_hover_text(crate::i18n::get().workspace.recent_workspaces.clone());
+                        }
                         if ui
                             .small_button("🔄")
                             .on_hover_text(crate::i18n::get().action.refresh_workspace.clone())
@@ -258,6 +285,29 @@ pub(crate) fn render_workspace_content(
         {
             if let Some(path) = open_folder_dialog() {
                 *action = AppAction::OpenWorkspace(path);
+            }
+        }
+
+        let recent_paths = &state.settings.settings().workspace.paths;
+        if !recent_paths.is_empty() {
+            ui.add_space(RECENT_WORKSPACES_SPACING);
+            ui.separator();
+            ui.add_space(RECENT_WORKSPACES_SPACING);
+            ui.heading(crate::i18n::get().workspace.recent_workspaces.clone());
+            ui.add_space(RECENT_WORKSPACES_ITEM_SPACING);
+            for path in recent_paths.iter().rev() {
+                ui.horizontal(|ui| {
+                    if ui
+                        .button("×")
+                        .on_hover_text(crate::i18n::get().action.remove_workspace.clone())
+                        .clicked()
+                    {
+                        *action = AppAction::RemoveWorkspace(path.clone());
+                    }
+                    if ui.selectable_label(false, path).clicked() {
+                        *action = AppAction::OpenWorkspace(std::path::PathBuf::from(path));
+                    }
+                });
             }
         }
     }

--- a/crates/katana-ui/tests/integration.rs
+++ b/crates/katana-ui/tests/integration.rs
@@ -827,7 +827,7 @@ fn test_persistence_workspace_roundtrip() {
     {
         let repo = katana_platform::JsonFileRepository::new(settings_path.to_path_buf());
         let settings = katana_platform::SettingsService::new(Box::new(repo));
-        let restored_ws = settings.settings().last_workspace.clone();
+        let restored_ws = settings.settings().workspace.last_workspace.clone();
 
         assert!(
             restored_ws.is_some(),
@@ -907,7 +907,7 @@ fn test_persistence_multiple_changes_accumulate() {
         let s = settings.settings();
 
         assert!(
-            s.last_workspace.is_some(),
+            s.workspace.last_workspace.is_some(),
             "last_workspace should be persisted"
         );
         assert_eq!(s.language, "ja", "language should be persisted");
@@ -938,7 +938,7 @@ fn test_persistence_corrupt_file_falls_back_to_defaults() {
         "Should fall back to default language"
     );
     assert!(
-        s.settings.settings().last_workspace.is_none(),
+        s.settings.settings().workspace.last_workspace.is_none(),
         "Should fall back to no workspace"
     );
 }
@@ -1738,4 +1738,123 @@ fn test_search_sidebar_buttons() {
         !filter_nodes.is_empty(),
         "Filter button (\u{25BC}) must be present in the workspace sidebar"
     );
+}
+
+#[test]
+fn test_integration_open_workspace_restores_tabs() {
+    let settings_dir = tempfile::tempdir().unwrap();
+    let settings_path = settings_dir.path().join("settings.json");
+    let ws_dir = tempfile::tempdir().unwrap();
+    let doc_path1 = ws_dir.path().join("doc1.md");
+    let doc_path2 = ws_dir.path().join("doc2.md");
+    std::fs::write(&doc_path1, "# Doc 1").unwrap();
+    std::fs::write(&doc_path2, "# Doc 2").unwrap();
+
+    // Session 1: Open workspace, open tabs
+    {
+        let mut harness = setup_harness_with_json_repo(&settings_path);
+        harness.step();
+        harness
+            .state_mut()
+            .trigger_action(AppAction::OpenWorkspace(ws_dir.path().to_path_buf()));
+        harness.step();
+        harness
+            .state_mut()
+            .trigger_action(AppAction::SelectDocument(doc_path1.clone()));
+        harness.step();
+        harness
+            .state_mut()
+            .trigger_action(AppAction::SelectDocument(doc_path2.clone()));
+        harness.step();
+
+        // Ensure tabs are saved
+        let settings = harness.state_mut().app_state_mut().settings.settings();
+        assert_eq!(settings.workspace.open_tabs.len(), 2);
+        assert_eq!(settings.workspace.active_tab_idx, Some(1));
+    }
+
+    // Session 2: Reload same workspace, tabs should be restored
+    {
+        let mut harness = setup_harness_with_json_repo(&settings_path);
+        harness.step();
+        harness
+            .state_mut()
+            .trigger_action(AppAction::OpenWorkspace(ws_dir.path().to_path_buf()));
+        harness.step();
+
+        let state = harness.state_mut().app_state_mut();
+        assert_eq!(state.open_documents.len(), 2);
+        assert_eq!(state.active_doc_idx, Some(1));
+    }
+}
+
+#[test]
+fn test_integration_remove_workspace() {
+    let settings_dir = tempfile::tempdir().unwrap();
+    let settings_path = settings_dir.path().join("settings.json");
+    let ws_dir = tempfile::tempdir().unwrap();
+
+    let mut harness = setup_harness_with_json_repo(&settings_path);
+    harness.step();
+    harness
+        .state_mut()
+        .trigger_action(AppAction::OpenWorkspace(ws_dir.path().to_path_buf()));
+    harness.step();
+
+    // Verify it's in paths
+    {
+        let settings = harness.state_mut().app_state_mut().settings.settings();
+        assert!(settings
+            .workspace
+            .paths
+            .contains(&ws_dir.path().display().to_string()));
+    }
+
+    // Remove it
+    harness
+        .state_mut()
+        .trigger_action(AppAction::RemoveWorkspace(
+            ws_dir.path().display().to_string(),
+        ));
+    harness.step();
+
+    // Verify it's removed
+    {
+        let settings = harness.state_mut().app_state_mut().settings.settings();
+        assert!(!settings
+            .workspace
+            .paths
+            .contains(&ws_dir.path().display().to_string()));
+    }
+}
+
+#[test]
+fn test_integration_save_workspace_state_error() {
+    let settings_dir = tempfile::tempdir().unwrap();
+    // Use a directory path as the settings file path so saving will fail
+    let settings_path = settings_dir.path().to_path_buf();
+    let ws_dir = tempfile::tempdir().unwrap();
+
+    let mut harness = setup_harness_with_json_repo(&settings_path);
+    harness.step();
+
+    // Actions that trigger saving workspace state
+    harness
+        .state_mut()
+        .trigger_action(AppAction::OpenWorkspace(ws_dir.path().to_path_buf()));
+    harness.step();
+
+    // Removing a workspace triggers save in handle_remove_workspace
+    harness
+        .state_mut()
+        .trigger_action(AppAction::RemoveWorkspace(
+            ws_dir.path().display().to_string(),
+        ));
+    harness.step();
+
+    // Changing active documents triggers save_workspace_state
+    harness
+        .state_mut()
+        .trigger_action(AppAction::CloseDocument(0));
+    harness.step();
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
Task 1: ワークスペース永続化機能の実装

## 対応内容
* AppSettingsのワークスペース関連設定へのネスト化および履歴管理処理を追加
* 履歴削除（AppAction::RemoveWorkspace）とUI表示を追加
* タブ開閉時の自動保存と起動時の自動復元処理を追加
* マイグレーション対応 (0.1.4 -> 0.2.0)
* 統合テストカバレッジ(未網羅行0)の達成

## 影響範囲
* 設定ファイルのスキーマ変更およびファイルI/O
* サイドバーUIおよび起動時のファイル復帰シーケンス

## 動作確認結果
* `make check` (Linter, Unit Tests, Coverage) を全てパス。
* Self Review スキルによる事前チェックを実施済み。