### PR TITLE
fix: Resolve Japanese font baseline jitter in Monospace context

### DIFF
--- a/crates/katana-ui/src/font_loader.rs
+++ b/crates/katana-ui/src/font_loader.rs
@@ -41,8 +41,8 @@ impl SystemFontLoader {
     ) -> FontDefinitions {
         let mut fonts = FontDefinitions::default();
 
-        let prop_name = Self::load_first_valid(&mut fonts, proportional_candidates);
-        let mono_name = Self::load_first_valid(&mut fonts, monospace_candidates);
+        let prop_name = Self::load_first_valid(&mut fonts, proportional_candidates, None, "");
+        let mono_name = Self::load_first_valid(&mut fonts, monospace_candidates, None, "");
 
         // Add primary fonts mapped to their corresponding families
         if let Some(name) = &prop_name {
@@ -52,10 +52,25 @@ impl SystemFontLoader {
             Self::prepend_primary(&mut fonts, FontFamily::Monospace, name);
         }
 
-        // Cross-fallbacks for comprehensive CJK coverage in code blocks, and vice versa
-        if let Some(name) = &prop_name {
+        // Cross-fallbacks for comprehensive CJK coverage in code blocks
+        // We apply a positive `y_offset_factor` to align the CJK fallback's baseline with the Menlo primary font
+        const MONO_FALLBACK_Y_OFFSET_FACTOR: f32 = 0.50;
+        let tweaked_fallback = egui::FontTweak {
+            scale: 1.0,
+            y_offset_factor: MONO_FALLBACK_Y_OFFSET_FACTOR,
+            y_offset: 0.0,
+        };
+        let mono_fallback_name = Self::load_first_valid(
+            &mut fonts,
+            proportional_candidates,
+            Some(tweaked_fallback),
+            "_mono_fallback",
+        );
+
+        if let Some(name) = &mono_fallback_name {
             Self::append_fallback(&mut fonts, FontFamily::Monospace, name);
         }
+        // Mono to Prop fallback (usually English Monaco fallback for Proportional CJK)
         if let Some(name) = &mono_name {
             Self::append_fallback(&mut fonts, FontFamily::Proportional, name);
         }
@@ -67,18 +82,29 @@ impl SystemFontLoader {
         fonts
     }
 
-    fn load_first_valid(fonts: &mut FontDefinitions, candidates: &[&str]) -> Option<String> {
+    fn load_first_valid(
+        fonts: &mut FontDefinitions,
+        candidates: &[&str],
+        tweak: Option<egui::FontTweak>,
+        suffix: &str,
+    ) -> Option<String> {
         for &path in candidates {
             if let Ok(data) = fs::read(path) {
                 let name = std::path::Path::new(path)
                     .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or("cjk_font")
-                    .to_string();
-                fonts.font_data.insert(
-                    name.clone(),
-                    std::sync::Arc::new(FontData::from_owned(data)),
-                );
+                    .to_string()
+                    + suffix;
+
+                let mut font_data = FontData::from_owned(data);
+                if let Some(t) = tweak {
+                    font_data.tweak = t;
+                }
+
+                fonts
+                    .font_data
+                    .insert(name.clone(), std::sync::Arc::new(font_data));
                 return Some(name);
             }
         }
@@ -275,7 +301,11 @@ mod tests {
                     Color32::WHITE,
                 );
                 eng_glyph = galley.rows[0].glyphs.iter().find(|g| g.chr == 'L').copied();
-                jpn_glyph = galley.rows[0].glyphs.iter().find(|g| g.chr == 'ア').copied();
+                jpn_glyph = galley.rows[0]
+                    .glyphs
+                    .iter()
+                    .find(|g| g.chr == 'ア')
+                    .copied();
             });
         });
 
@@ -317,5 +347,77 @@ mod tests {
     fn test_font_jitter_5_tab_name() {
         // Tab name uses Button (14.0)
         assert_font_jitter("Tab Name", 14.0);
+    }
+
+    #[test]
+    fn test_font_jitter_6_monospace() {
+        let preset = DiagramColorPreset::current();
+        let fonts = SystemFontLoader::build_font_definitions(
+            &preset.proportional_font_candidates,
+            &preset.monospace_font_candidates,
+            &preset.emoji_font_candidates,
+            None,
+            None,
+        );
+        let ctx = Context::default();
+        ctx.set_fonts(fonts);
+
+        let text = "cd infrastructures/tools/crypt-decrypt の復号化".to_string();
+        let mut eng_glyph = None;
+        let mut jpn_glyph = None;
+
+        let mut primitives = vec![];
+        let _ = ctx.run(Default::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                let galley = ui.painter().layout_no_wrap(
+                    text.clone(),
+                    FontId::monospace(14.0),
+                    Color32::WHITE,
+                );
+                eng_glyph = galley.rows[0].glyphs.iter().find(|g| g.chr == 'c').copied();
+                jpn_glyph = galley.rows[0]
+                    .glyphs
+                    .iter()
+                    .find(|g| g.chr == '復')
+                    .copied();
+
+                let shapes = vec![egui::epaint::ClippedShape {
+                    clip_rect: egui::Rect::EVERYTHING,
+                    shape: egui::epaint::Shape::galley(egui::Pos2::ZERO, galley, Color32::WHITE),
+                }];
+                primitives = ctx.tessellate(shapes, 1.0);
+            });
+        });
+
+        let eng_glyph = eng_glyph.expect("English char not found");
+        let jpn_glyph = jpn_glyph.expect("Japanese char not found");
+
+        // Find visual min y for English char
+        let mut eng_min_y = f32::INFINITY;
+        let mut jpn_min_y = f32::INFINITY;
+
+        if let egui::epaint::Primitive::Mesh(mesh) = &primitives[0].primitive {
+            for v in &mesh.vertices {
+                if v.pos.x >= eng_glyph.logical_rect().min.x
+                    && v.pos.x <= eng_glyph.logical_rect().max.x
+                {
+                    eng_min_y = eng_min_y.min(v.pos.y);
+                }
+                if v.pos.x >= jpn_glyph.logical_rect().min.x
+                    && v.pos.x <= jpn_glyph.logical_rect().max.x
+                {
+                    jpn_min_y = jpn_min_y.min(v.pos.y);
+                }
+            }
+        }
+
+        // Allow up to 1.0 pixel difference for natural font optical alignment,
+        // but 3.0+ (like 13 vs 10) is a jitter bug.
+        let diff = (eng_min_y - jpn_min_y).abs();
+        assert!(
+            diff <= 1.5,
+            "ガタツキ (Jitter) in Monospace visual mesh: English 'c' y={} vs Japanese '復' y={} (Diff: {})",
+            eng_min_y, jpn_min_y, diff
+        );
     }
 }

--- a/crates/katana-ui/src/main.rs
+++ b/crates/katana-ui/src/main.rs
@@ -429,13 +429,17 @@ mod tests {
             .get(&egui::FontFamily::Monospace)
             .expect("Monospace family missing");
         let prop_name = load_first_font(PROP_CANDIDATES).unwrap().0;
+        let mono_fallback_name = format!("{}_mono_fallback", prop_name);
         assert!(
-            monospace.contains(&prop_name),
+            monospace.contains(&mono_fallback_name),
             "Proportional font should be in Monospace family as CJK fallback"
         );
         let mono_name = load_first_font(MONO_CANDIDATES).unwrap().0;
         let mono_pos = monospace.iter().position(|n| n == &mono_name).unwrap();
-        let prop_pos = monospace.iter().position(|n| n == &prop_name).unwrap();
+        let prop_pos = monospace
+            .iter()
+            .position(|n| n == &mono_fallback_name)
+            .unwrap();
         assert!(
             mono_pos < prop_pos,
             "Monospace font must appear before proportional (CJK fallback)"


### PR DESCRIPTION
Fixes the 7-pixel Y-coordinate mismatch between English (Menlo) and Japanese (CJK Fallback) in the Monospace family. The CJK fallback is extracted to a dedicated Monospace-fallback instance and an explicit `y_offset_factor` of 0.50 is applied. A tessellated MESH TDD test was implemented to ensure optical baseline alignment.