### PR TITLE
fix: Task 1 CPU無限ループおよびタブ切り替えバグ修正

### DIFF
--- a/crates/katana-ui/src/shell.rs
+++ b/crates/katana-ui/src/shell.rs
@@ -194,9 +194,26 @@ impl KatanaApp {
 
     /// Reflects only text changes (keeps existing images for diagrams).
     fn refresh_preview(&mut self, path: &std::path::Path, source: &str) {
+        let h = hash_str(source);
         let path_buf = path.to_path_buf();
-        Self::get_preview_pane(&mut self.tab_previews, path_buf)
+
+        let current_hash = self
+            .tab_previews
+            .iter()
+            .find(|t| t.path == path_buf)
+            .map(|t| t.hash)
+            .unwrap_or(0);
+
+        if current_hash != 0 && current_hash == h {
+            return;
+        }
+
+        Self::get_preview_pane(&mut self.tab_previews, path_buf.clone())
             .update_markdown_sections(source, path);
+
+        if let Some(tab) = self.tab_previews.iter_mut().find(|t| t.path == path_buf) {
+            tab.hash = h;
+        }
     }
 
     fn full_refresh_preview(

--- a/crates/katana-ui/src/svg_loader.rs
+++ b/crates/katana-ui/src/svg_loader.rs
@@ -251,7 +251,16 @@ impl ImageLoader for KatanaSvgLoader {
                     }
                 }
                 Ok(BytesPoll::Pending { size }) => Ok(ImagePoll::Pending { size }),
-                Err(err) => Err(err),
+                Err(err) => {
+                    bucket.entries.push(SvgCacheEntry {
+                        size_hint,
+                        data: Entry {
+                            last_used: AtomicU64::new(self.pass_index.load(Relaxed)),
+                            result: Err(err.to_string()),
+                        },
+                    });
+                    Err(err)
+                }
             }
         }
     }

--- a/openspec/changes/v0-6-0-ui-bug-fixes/tasks.md
+++ b/openspec/changes/v0-6-0-ui-bug-fixes/tasks.md
@@ -4,13 +4,13 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 
 ## 1. P0 CPU無限ループ および タブ切り替えバグ修正
 
-- [ ] 1.1 `KatanaSvgLoader::load` が失敗した場合にエラーを返し、キャッシュさせるようにする (`LoadError::NotSupported` の利用)
-- [ ] 1.2 `shell.rs` において、`tab.hash` （キャッシュ）を判定し、同一ハッシュなら早期リターンするよう最適化 (CPU100%バグ修正)
+- [x] 1.1 `KatanaSvgLoader::load` が失敗した場合にエラーを返し、キャッシュさせるようにする (`LoadError::NotSupported` の利用)
+- [x] 1.2 `shell.rs` において、`tab.hash` （キャッシュ）を判定し、同一ハッシュなら早期リターンするよう最適化 (CPU100%バグ修正)
 
 ### Definition of Done (DoD)
 
-- [ ] CPUが100%に張り付く現象が消失し、`tests::svg_loader` などが通過する
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+- [x] CPUが100%に張り付く現象が消失し、`tests::svg_loader` などが通過する
+- [/] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ## 2. P1/P3/P4 UI レンダリングバグ修正
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)
- Task 1: CPU無限ループおよびタブ切り替えバグ修正

## 対応内容 (Changes Made)
- KatanaSvgLoader::load が失敗した場合にエラーを返し、キャッシュさせるように修正
- shell.rs において、tab.hash判定を refresh_preview に追加し、早期リターンするよう最適化

## 影響範囲 (Impact Scope)
- Markdownのパース・レンダリング (UIプレビュー)

## 動作確認結果 (Verification Results)
- make check すべてパス
