### PR TITLE
fix: インラインコード等のテキスト配置をCenterへ修正

### DIFF
--- a/crates/katana-ui/src/html_renderer.rs
+++ b/crates/katana-ui/src/html_renderer.rs
@@ -488,7 +488,7 @@ impl<'a> HtmlRenderer<'a> {
                     job,
                     self.ui.style().as_ref(),
                     egui::FontSelection::Default,
-                    egui::Align::BOTTOM,
+                    egui::Align::Center,
                 );
             }
             HtmlNode::Emphasis(children) => {
@@ -510,7 +510,7 @@ impl<'a> HtmlRenderer<'a> {
                     job,
                     self.ui.style().as_ref(),
                     egui::FontSelection::Default,
-                    egui::Align::BOTTOM,
+                    egui::Align::Center,
                 );
             }
             _ => {}

--- a/crates/katana-ui/tests/preview_pane.rs
+++ b/crates/katana-ui/tests/preview_pane.rs
@@ -1186,7 +1186,7 @@ fn inline_emoji_stays_within_text_line_height_budget() {
 }
 
 #[test]
-fn markdown_text_uses_bottom_vertical_alignment_for_mixed_cjk_runs() {
+fn markdown_text_uses_center_vertical_alignment_for_mixed_cjk_runs() {
     let mut pane = PreviewPane::default();
     pane.update_markdown_sections(
         "KatanA は AIエージェントと共に仕様駆動開発を行う時代のために設計されたツールです。\n",
@@ -1240,13 +1240,13 @@ fn markdown_text_uses_bottom_vertical_alignment_for_mixed_cjk_runs() {
             .job
             .sections
             .iter()
-            .all(|section| section.format.valign == egui::Align::BOTTOM),
-        "mixed CJK markdown text should use bottom baseline alignment"
+            .all(|section| section.format.valign == egui::Align::Center),
+        "mixed CJK markdown text should use center baseline alignment"
     );
 }
 
 #[test]
-fn html_text_uses_bottom_vertical_alignment_for_mixed_cjk_runs() {
+fn html_text_uses_center_vertical_alignment_for_mixed_cjk_runs() {
     let mut pane = PreviewPane::default();
     pane.sections = vec![RenderedSection::Markdown(
         "<p>KatanA は AIエージェントと共に仕様駆動開発を行う時代のために設計されたツールです。</p>\n"
@@ -1300,8 +1300,8 @@ fn html_text_uses_bottom_vertical_alignment_for_mixed_cjk_runs() {
             .job
             .sections
             .iter()
-            .all(|section| section.format.valign == egui::Align::BOTTOM),
-        "mixed CJK html text should use bottom baseline alignment"
+            .all(|section| section.format.valign == egui::Align::Center),
+        "mixed CJK html text should use center baseline alignment"
     );
 }
 

--- a/openspec/changes/v0-6-1-ui-deferred-fixes/tasks.md
+++ b/openspec/changes/v0-6-1-ui-deferred-fixes/tasks.md
@@ -4,12 +4,12 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 
 ## 1. P3 インラインコード配置最適化
 
-- [ ] 1.1 `pulldown.rs` 内の `self.line.append_to` に使用される `egui::Align` を `BOTTOM` から `Center` へ変更。
-- [ ] 1.2 `katana-ui/tests/preview_pane.rs` において、`html_...` となっている旧テストケースを `Center` 対応へと修正する。
+- [x] 1.1 `pulldown.rs` 内の `self.line.append_to` に使用される `egui::Align` を `BOTTOM` から `Center` へ変更。
+- [x] 1.2 `katana-ui/tests/preview_pane.rs` において、`html_...` となっている旧テストケースを `Center` 対応へと修正する。
 
 ### Definition of Done (DoD)
 
-- [ ] インラインコードのアラインメントが中央寄りになり、テストが問題なくパスする
+- [x] インラインコードのアラインメントが中央寄りになり、テストが問題なくパスする
 - [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ## 2. 実験機能 テーブル描画変更

--- a/vendor/egui_commonmark/src/parsers/pulldown.rs
+++ b/vendor/egui_commonmark/src/parsers/pulldown.rs
@@ -211,7 +211,7 @@ impl<'a> CommonMarkViewerInternal<'a> {
                 &mut layout_job,
                 &style,
                 egui::FontSelection::Default,
-                egui::Align::BOTTOM,
+                egui::Align::Center,
             );
         }
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)
v0-6-1-ui-deferred-fixes タスク 1 の「P3 インラインコード配置最適化」を実装しました。

## 対応内容 (Changes Made)
- `pulldown.rs` 内の `self.line.append_to` に使用される `egui::Align` を `BOTTOM` から `Center` へ変更。
- `katana-ui/tests/preview_pane.rs` におけるテストケースの内容を `Center` 対応へと修正し、「mixed CJK markdown/html text should use center baseline alignment」という検証へと切り替えました。
- `html_renderer.rs` 内における `Align::BOTTOM` の指定もテスト要件の通り `Center` へと変更しました。

## 影響範囲 (Impact Scope)
- Markdown/HTML両方のインラインテキストのアラインメント（`Center` 基準）
- 関連するテスト（`test_preview_pane` 等のUIテスト群）

## 動作確認結果 (Verification Results)
- `cargo test --workspace` および `cargo test preview_pane` においてすべてのテストがパスすることを確認しました。
