### PR TITLE
feat: 自動更新 - ZIP取得・展開および再起動スクリプトの生成

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Networking / Auto Update
 ureq = { version = "2.10", features = ["json"] }
 semver = "1.0"
+zip = "2.2"
 
 # Testing
 tempfile = "3"

--- a/crates/katana-core/Cargo.toml
+++ b/crates/katana-core/Cargo.toml
@@ -23,6 +23,7 @@ headless_chrome.workspace = true
 base64 = "0.22"
 ureq.workspace = true
 semver.workspace = true
+zip.workspace = true
 
 [dev-dependencies]
 pulldown-cmark = "0.13.2"

--- a/crates/katana-core/src/update.rs
+++ b/crates/katana-core/src/update.rs
@@ -79,6 +79,73 @@ pub fn check_for_updates(
     parse_release_response(current_version, &resp_string)
 }
 
+/// Downloads a file from the given URL to the destination path.
+pub fn download_update(url: &str, dest_path: &std::path::Path) -> anyhow::Result<()> {
+    let response = ureq::get(url)
+        .set("User-Agent", concat!("KatanA/", env!("CARGO_PKG_VERSION")))
+        .call()?;
+    let mut reader = response.into_reader();
+    let mut out_file = std::fs::File::create(dest_path)?;
+    std::io::copy(&mut reader, &mut out_file)?;
+    Ok(())
+}
+
+/// Extracts a ZIP archive into the destination directory.
+pub fn extract_update(
+    zip_path: &std::path::Path,
+    extract_to_dir: &std::path::Path,
+) -> anyhow::Result<()> {
+    let file = std::fs::File::open(zip_path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+    archive.extract(extract_to_dir)?;
+    Ok(())
+}
+
+/// Generates the bash script used for atomic replacement and quarantine removal.
+pub fn generate_relauncher_script(
+    extracted_app: &std::path::Path,
+    target_app: &std::path::Path,
+    script_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let content = format!(
+        r#"#!/bin/bash
+# KatanA Auto-Update Relauncher Script
+set -e
+
+# Wait a brief moment to ensure the old process has fully exited
+sleep 1
+
+echo "Replacing application..."
+rm -rf "{target}"
+mv "{extracted}" "{target}"
+
+echo "Removing Gatekeeper quarantine attributes..."
+xattr -cr "{target}"
+
+echo "Relaunching application..."
+open "{target}"
+
+echo "Cleaning up..."
+rm -f "$0"
+"#,
+        target = target_app.display(),
+        extracted = extracted_app.display()
+    );
+
+    std::fs::write(script_path, content)?;
+
+    const RELAUNCHER_SCRIPT_PERMISSIONS: u32 = 0o755;
+
+    // Make the script executable
+    let mut perms = std::fs::metadata(script_path)?.permissions();
+    perms.set_mode(RELAUNCHER_SCRIPT_PERMISSIONS);
+    std::fs::set_permissions(script_path, perms)?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -136,7 +203,7 @@ mod tests {
             if let Ok((mut stream, _)) = listener.accept() {
                 let mut buf = [0; 1024];
                 let _ = stream.read(&mut buf); // Consume the request headers to prevent TCP RST
-                
+
                 let body = r#"{
                     "tag_name": "v0.7.0",
                     "html_url": "https://github.com/HiroyukiFuruno/KatanA/releases/tag/v0.7.0",
@@ -161,5 +228,93 @@ mod tests {
         // Point to an unbindable/closed local port
         let res = check_for_updates("0.6.4", Some("http://127.0.0.1:0/impossible"));
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_generate_relauncher_script() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let extracted_path = temp_dir.path().join("KatanA-extract.app");
+        let target_path = temp_dir.path().join("KatanA.app");
+        let script_path = temp_dir.path().join("relauncher.sh");
+
+        generate_relauncher_script(&extracted_path, &target_path, &script_path).unwrap();
+
+        assert!(script_path.exists());
+
+        let content = std::fs::read_to_string(&script_path).unwrap();
+        assert!(content.contains(&format!("rm -rf \"{}\"", target_path.display())));
+        assert!(content.contains(&format!(
+            "mv \"{}\" \"{}\"",
+            extracted_path.display(),
+            target_path.display()
+        )));
+        assert!(content.contains(&format!("xattr -cr \"{}\"", target_path.display())));
+
+        let perms = std::fs::metadata(&script_path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o111, 0o111, "Script must be executable");
+    }
+
+    #[test]
+    fn test_download_update() {
+        use std::io::Write;
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let url = format!("http://127.0.0.1:{}/update.zip", port);
+
+        thread::spawn(move || {
+            use std::io::Read;
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0; 1024];
+                let _ = stream.read(&mut buf);
+
+                let body = b"mock zip payload";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.write_all(body);
+            }
+        });
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dest = temp_dir.path().join("update.zip");
+
+        download_update(&url, &dest).unwrap();
+        assert!(dest.exists());
+        assert_eq!(std::fs::read(&dest).unwrap(), b"mock zip payload");
+    }
+
+    #[test]
+    fn test_extract_update() {
+        use std::io::Write;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("test.zip");
+        let extract_dir = temp_dir.path().join("extracted");
+
+        // Create a dummy zip file
+        {
+            let file = std::fs::File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options = zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored);
+            zip.start_file("hello.txt", options.clone()).unwrap();
+            zip.write_all(b"Hello from ZIP").unwrap();
+            zip.add_directory("somedir/", options).unwrap();
+            zip.finish().unwrap();
+        }
+
+        extract_update(&zip_path, &extract_dir).unwrap();
+
+        let extracted_file = extract_dir.join("hello.txt");
+        assert!(extracted_file.exists());
+        assert_eq!(std::fs::read(&extracted_file).unwrap(), b"Hello from ZIP");
+        assert!(extract_dir.join("somedir").is_dir());
     }
 }

--- a/openspec/changes/v0_7_0-in-app-auto-update/tasks.md
+++ b/openspec/changes/v0_7_0-in-app-auto-update/tasks.md
@@ -12,7 +12,7 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 ## 1. アプリ内自動更新機能の実装 (Core Update Logic)
 
 - [x] 1.1 `katana-core` へのバージョンチェック機能実装 (GitHub Releases API連携。ローカル検証用APIオーバーライド機能を含む)
-- [ ] 1.2 `katana-core` への .zip ダウンロード・一時展開・Relauncher（ヘルパースクリプト）生成機能の実装
+- [x] 1.2 `katana-core` への .zip ダウンロード・一時展開・Relauncher（ヘルパースクリプト）生成機能の実装
 - [ ] 1.3 `katana-core` から Relauncher をバックグラウンド起動し、自身を終了させるフローの構築（置換・`xattr -cr`・テンポラリのクリーンアップ・再起動処理を委譲）
 - [ ] 1.4 `katana-core` へのチェック頻度や状態管理・エラーハンドリング機能の実装
 - [ ] 1.5 ローカルHTTPサーバーとダミーファイルを用いた、実リリース前の完全ローカル疑似E2Eテストの実行と検証


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要 (Overview)
自動更新機能（Task 1.2）のコア処理として、GitHub Releasesからの `.zip` ダウンロード・一時ディレクトリへの展開・アトミックな置換処理を行う `Relauncher` シェルスクリプト生成機能を `katana-core` に追加しました。

## 対応内容 (Changes Made)
- 依存関係 `zip` crate の追加 (Workspace層および `katana-core`)
- `download_update`: `ureq` によるアセットの取得保存処理
- `extract_update`: `zip` によるアセットの一時展開処理
- `generate_relauncher_script`: `sleep` 同期、`rm -rf`、`mv` 置換、および `xattr -cr` による Quarantine 除去ロジックを持つ bash バックグラウンド起動用スクリプトの生成機能
- ファイル I/O・ネットワーク通信を含む 100% カバレッジ確保用のモックテストの追加

## 影響範囲 (Impact Scope)
- ロジックは `update.rs` 側に集約
- AST Linterで検知されたパーミッション系のマジックナンバーの排除