### PR TITLE
feat: 自動更新 - 更新チェック頻度制御とステートマシン

### DIFF
--- a/crates/katana-core/src/update.rs
+++ b/crates/katana-core/src/update.rs
@@ -204,6 +204,62 @@ rm -rf "{temp_dir}"
     Ok(())
 }
 
+#[derive(Debug, Default)]
+pub enum UpdateState {
+    #[default]
+    Idle,
+    Checking,
+    UpdateAvailable(ReleaseInfo),
+    Downloading,
+    ReadyToRestart(UpdatePreparation),
+    Error(String),
+}
+
+pub struct UpdateManager {
+    pub current_version: String,
+    pub api_url_override: Option<String>,
+    pub target_app_path: std::path::PathBuf,
+    pub state: UpdateState,
+    pub last_checked: Option<std::time::Instant>,
+    pub check_interval: std::time::Duration,
+}
+
+impl UpdateManager {
+    pub fn new(current_version: String, target_app_path: std::path::PathBuf) -> Self {
+        const DEFAULT_CHECK_INTERVAL_SECS: u64 = 86_400;
+        Self {
+            current_version,
+            api_url_override: None,
+            target_app_path,
+            state: UpdateState::Idle,
+            last_checked: None,
+            check_interval: std::time::Duration::from_secs(DEFAULT_CHECK_INTERVAL_SECS),
+        }
+    }
+
+    pub fn should_check_for_updates(&self) -> bool {
+        match self.last_checked {
+            Some(last) => last.elapsed() >= self.check_interval,
+            None => true,
+        }
+    }
+
+    pub fn set_api_url_override(&mut self, url: String) {
+        self.api_url_override = Some(url);
+    }
+
+    pub fn set_check_interval(&mut self, interval: std::time::Duration) {
+        self.check_interval = interval;
+    }
+
+    pub fn transition_to(&mut self, new_state: UpdateState) {
+        if matches!(new_state, UpdateState::Checking) {
+            self.last_checked = Some(std::time::Instant::now());
+        }
+        self.state = new_state;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -463,5 +519,50 @@ mod tests {
             res.unwrap_err().to_string(),
             "Extracted update does not contain the expected application bundle"
         );
+    }
+
+    #[test]
+    fn test_update_manager_and_state() {
+        let target = std::path::PathBuf::from("/Applications/KatanA.app");
+        let mut manager = UpdateManager::new("0.6.4".to_string(), target.clone());
+
+        assert_eq!(manager.current_version, "0.6.4");
+        assert_eq!(manager.target_app_path, target);
+        assert!(matches!(manager.state, UpdateState::Idle));
+
+        // Default interval is 24 hours. Because last_checked is None, it should check.
+        assert!(manager.should_check_for_updates());
+
+        // Test API override
+        manager.set_api_url_override("http://localhost".to_string());
+        assert_eq!(
+            manager.api_url_override.as_deref(),
+            Some("http://localhost")
+        );
+
+        // Test interval override
+        manager.set_check_interval(std::time::Duration::from_secs(3600));
+        assert_eq!(manager.check_interval, std::time::Duration::from_secs(3600));
+
+        // State transition to Checking records the last_checked time
+        manager.transition_to(UpdateState::Checking);
+        assert!(matches!(manager.state, UpdateState::Checking));
+        assert!(manager.last_checked.is_some());
+
+        // Immediately checking again should be false (because 1 hour hasn't passed)
+        assert!(!manager.should_check_for_updates());
+
+        // Fast forward by faking last_checked time
+        manager.last_checked =
+            Some(std::time::Instant::now() - std::time::Duration::from_secs(4000));
+        assert!(manager.should_check_for_updates());
+
+        // Test another transition
+        manager.transition_to(UpdateState::Error("dummy error".to_string()));
+        assert!(matches!(manager.state, UpdateState::Error(_)));
+
+        // Ensure default works
+        let default_state = UpdateState::default();
+        assert!(matches!(default_state, UpdateState::Idle));
     }
 }

--- a/crates/katana-ui/tests/integration.rs
+++ b/crates/katana-ui/tests/integration.rs
@@ -231,8 +231,9 @@ fn test_integration_toc_panel_hides_when_disabled() {
 
     // Explicitly toggle TOC on
     harness.state_mut().trigger_action(AppAction::ToggleToc);
-    harness.step(); // Action processes
-    harness.step(); // Panel renders
+    for _ in 0..10 {
+        harness.step();
+    }
 
     // Verify panel is visible initially
     let toc_title = katana_ui::i18n::get().toc.title.clone();

--- a/openspec/changes/v0_7_0-in-app-auto-update/tasks.md
+++ b/openspec/changes/v0_7_0-in-app-auto-update/tasks.md
@@ -13,8 +13,8 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 
 - [x] 1.1 `katana-core` へのバージョンチェック機能実装 (GitHub Releases API連携。ローカル検証用APIオーバーライド機能を含む)
 - [x] 1.2 `katana-core` への .zip ダウンロード・一時展開・Relauncher（ヘルパースクリプト）生成機能の実装
-- [/] 1.3 `katana-core` から Relauncher をバックグラウンド起動し、自身を終了させるフローの構築（置換・`xattr -cr`・テンポラリのクリーンアップ・再起動処理を委譲）
-- [ ] 1.4 `katana-core` へのチェック頻度や状態管理・エラーハンドリング機能の実装
+- [x] 1.3 `katana-core` から Relauncher をバックグラウンド起動し、自身を終了させるフローの構築（置換・`xattr -cr`・テンポラリのクリーンアップ・再起動処理を委譲）
+- [/] 1.4 `katana-core` へのチェック頻度や状態管理・エラーハンドリング機能の実装
 - [ ] 1.5 ローカルHTTPサーバーとダミーファイルを用いた、実リリース前の完全ローカル疑似E2Eテストの実行と検証
 
 ### Definition of Done (DoD)

--- a/openspec/changes/v0_7_0-in-app-auto-update/tasks.md
+++ b/openspec/changes/v0_7_0-in-app-auto-update/tasks.md
@@ -14,7 +14,7 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 - [x] 1.1 `katana-core` へのバージョンチェック機能実装 (GitHub Releases API連携。ローカル検証用APIオーバーライド機能を含む)
 - [x] 1.2 `katana-core` への .zip ダウンロード・一時展開・Relauncher（ヘルパースクリプト）生成機能の実装
 - [x] 1.3 `katana-core` から Relauncher をバックグラウンド起動し、自身を終了させるフローの構築（置換・`xattr -cr`・テンポラリのクリーンアップ・再起動処理を委譲）
-- [/] 1.4 `katana-core` へのチェック頻度や状態管理・エラーハンドリング機能の実装
+- [x] 1.4 `katana-core` へのチェック頻度や状態管理・エラーハンドリング機能の実装
 - [ ] 1.5 ローカルHTTPサーバーとダミーファイルを用いた、実リリース前の完全ローカル疑似E2Eテストの実行と検証
 
 ### Definition of Done (DoD)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要 (Overview)
自動更新機能（Task 1.4）のフロントエンド連携に向けた基盤として、アップデートフローの状態を安全に管理し、ポーリングによる頻繁なGitHub APIコールを抑制するための `UpdateManager` とステートマシン `UpdateState` を実装しました。

## 対応内容 (Changes Made)
- `UpdateState` 列挙型の追加（Idle, Checking, UpdateAvailable, Downloading, ReadyToRestart, Error）
  - Clippy の `derivable_impls` ルールに従い手動実装を避け `#[derive(Default)]` および `#[default]` で正規化
- `UpdateManager` 構造体の追加
  - 初回・定期実行判定の実装 (`should_check_for_updates`)
  - デフォルトのインターバル（24時間）および任意の上書き機能 (`set_check_interval`)
  - AST Linter (`magic-number`) に準拠した名前付き定数 (`DEFAULT_CHECK_INTERVAL_SECS`) へ抽出
  - 状態遷移のラップとAPI制限回避のための `last_checked` タイムスタンプ自動記録機構
- ステート遷移およびタイマー判定の 100% C0 カバレッジテスト追加
- [Fix] CI上のフレーム間競合によるUI結合テストのFlakyエラー解消 (`test_integration_toc_panel_hides_when_disabled`)

## 影響範囲 (Impact Scope)
- ロジックは `katana-core/src/update.rs` に集約
- 今後実装される `katana-ui` のバックグラウンドポーリング機能によりこの状態が参照されます