### PR TITLE
fix: macOS/Metal環境におけるハイライト背景の消失バグを修正

### DIFF
--- a/crates/katana-ui/src/shell_ui.rs
+++ b/crates/katana-ui/src/shell_ui.rs
@@ -1231,7 +1231,7 @@ pub(crate) fn render_editor_content(
                         egui::Color32::from_black_alpha(HIGHLIGHT_ALPHA)
                     };
                     ui.painter()
-                        .rect_filled(highlight_rect, 0.0, highlight_color);
+                        .rect_filled(highlight_rect, 1.0, highlight_color);
                 } else {
                     state.active_editor_line = None;
                 }
@@ -1283,7 +1283,7 @@ pub(crate) fn render_editor_content(
                             egui::pos2(ln_rect.min.x, response.rect.min.y + pos_start.min.y),
                             egui::pos2(response.rect.max.x, response.rect.min.y + pos_end.max.y),
                         );
-                        ui.painter().rect_filled(highlight_rect, 0.0, hover_color);
+                        ui.painter().rect_filled(highlight_rect, 1.0, hover_color);
                     }
                 }
 
@@ -2690,7 +2690,7 @@ impl eframe::App for KatanaApp {
                             )
                         };
                         let fill_color = bg_color.gamma_multiply(opacity);
-                        ui.painter().rect_filled(content_rect, 0.0, fill_color);
+                        ui.painter().rect_filled(content_rect, 1.0, fill_color);
 
                         let text_color = if is_dark {
                             egui::Color32::WHITE

--- a/openspec/changes/v0-7-3-tab-ux-improvements/tasks.md
+++ b/openspec/changes/v0-7-3-tab-ux-improvements/tasks.md
@@ -11,16 +11,16 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 
 ## 1. ハイライト背景バグ調査・修正
 
-- [ ] 1.1 再現条件の調査（特定GPU/描画環境、macOS バージョン、egui のバージョン）。※技術負債メモに記録されている「コードブロック背景色が `syntect` に強制上書きされる問題」と同一事象の可能性があるため、調査時に関連性を確認すること
-- [ ] 1.2 egui の `Painter::rect_filled` / `Frame::fill` の描画パスを追跡し、背景が描画されないコードパスを特定
-- [ ] 1.3 修正実装（描画パス変更またはフォールバック追加）
-- [ ] 1.4 ユーザーへのUIスナップショット（画像等）の提示および動作報告
-- [ ] 1.5 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+- [x] 1.1 再現条件の調査（特定GPU/描画環境、macOS バージョン、egui のバージョン）。※技術負債メモに記録されている「コードブロック背景色が `syntect` に強制上書きされる問題」と同一事象の可能性があるため、調査時に関連性を確認すること
+- [x] 1.2 egui の `Painter::rect_filled` / `Frame::fill` の描画パスを追跡し、背景が描画されないコードパスを特定
+- [x] 1.3 修正実装（描画パス変更またはフォールバック追加）
+- [x] 1.4 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [x] 1.5 ユーザーからのフィードバックに基づくUIの微調整および改善実装
 
 ### Definition of Done (DoD)
 
-- [ ] 再現していた環境で背景が表示されることを確認
-- [ ] `make check` が exit code 0 で通過
+- [x] 再現していた環境で背景が表示されることを確認
+- [x] `make check` が exit code 0 で通過
 - [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ---

--- a/vendor/egui_commonmark/src/parsers/pulldown.rs
+++ b/vendor/egui_commonmark/src/parsers/pulldown.rs
@@ -1534,7 +1534,7 @@ impl<'a> CommonMarkViewerInternal<'a> {
                                 } else {
                                     egui::Color32::from_black_alpha(15)
                                 };
-                                ui.painter().rect_filled(rect, 0.0, highlight_color);
+                                ui.painter().rect_filled(rect, 1.0, highlight_color);
                             }
                         }
                         if let Some(hovered) = &mut self.hovered_spans {
@@ -1546,7 +1546,7 @@ impl<'a> CommonMarkViewerInternal<'a> {
                                     } else {
                                         egui::Color32::from_black_alpha(8)
                                     };
-                                    ui.painter().rect_filled(rect, 0.0, hover_color);
+                                    ui.painter().rect_filled(rect, 1.0, hover_color);
                                 }
                             }
                         }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)
v0.7.3 Tab UX Improvements の Task 1 (ハイライト背景バグの調査・修正)

## 対応内容 (Changes Made)
- macOS (Metal) 描画時の wgpu エッジケース（透過色かつ Rounding::ZERO の矩形消失）を回避するため、関連する `egui::Painter::rect_filled` 等の使用箇所で `Rounding(1.0)` を指定するよう修正
- 対象: エディタ内のアクティブ行ハイライト, ホバーハイライト, スプラッシュ画面, プレビュー（egui_commonmark）内の脚注・コードブロックハイライト背景

## 影響範囲 (Impact Scope)
- `crates/katana-ui/src/shell_ui.rs` (背景色描画ロジック)
- `vendor/egui_commonmark/src/parsers/pulldown.rs` (プレビュー内のインライン要素ホバー・アクティブ行ハイライト)

## 動作確認結果 (Verification Results)
- `make check` 成功
- ローカルユーザーによる再現環境での動作確認完了（表示回復・デグレードなし）