### PR TITLE
hotfix: v0.7.3 タブ操作UXのコミット漏れ復旧

### DIFF
--- a/crates/katana-ui/src/shell.rs
+++ b/crates/katana-ui/src/shell.rs
@@ -35,6 +35,12 @@ pub(crate) const TAB_NAV_BUTTONS_AREA_WIDTH: f32 = 80.0;
 /// Inter-tab spacing provided on the right side of each tab (px).
 pub(crate) const TAB_INTER_ITEM_SPACING: f32 = 4.0;
 
+/// Lerp animation duration for the tab drop indicator line (seconds).
+pub(crate) const TAB_DROP_ANIMATION_TIME: f32 = 0.1;
+
+/// Width of the vertical line indicating where a tab will be dropped (px).
+pub(crate) const TAB_DROP_INDICATOR_WIDTH: f32 = 2.5;
+
 /// Initial number of visible rows for the text editor TextEdit.
 pub(crate) const EDITOR_INITIAL_VISIBLE_ROWS: usize = 40;
 

--- a/crates/katana-ui/src/shell_ui.rs
+++ b/crates/katana-ui/src/shell_ui.rs
@@ -28,8 +28,9 @@ fn invisible_label(text: &str) -> egui::RichText {
 use crate::shell::{
     ACTIVE_FILE_HIGHLIGHT_ROUNDING, EDITOR_INITIAL_VISIBLE_ROWS, FILE_TREE_PANEL_DEFAULT_WIDTH,
     FILE_TREE_PANEL_MIN_WIDTH, NO_WORKSPACE_BOTTOM_SPACING, RECENT_WORKSPACES_ITEM_SPACING,
-    RECENT_WORKSPACES_SPACING, SCROLL_SYNC_DEAD_ZONE, TAB_INTER_ITEM_SPACING,
-    TAB_NAV_BUTTONS_AREA_WIDTH, TAB_TOOLTIP_SHOW_DELAY_SECS, TREE_LABEL_HOFFSET, TREE_ROW_HEIGHT,
+    RECENT_WORKSPACES_SPACING, SCROLL_SYNC_DEAD_ZONE, TAB_DROP_ANIMATION_TIME,
+    TAB_DROP_INDICATOR_WIDTH, TAB_INTER_ITEM_SPACING, TAB_NAV_BUTTONS_AREA_WIDTH,
+    TAB_TOOLTIP_SHOW_DELAY_SECS, TREE_LABEL_HOFFSET, TREE_ROW_HEIGHT,
 };
 use crate::theme_bridge;
 use katana_platform::{PaneOrder, SplitDirection};
@@ -809,7 +810,7 @@ pub(crate) fn render_tab_bar(ui: &mut egui::Ui, state: &mut AppState, action: &m
 
     let mut close_idx: Option<usize> = None;
     let mut tab_action: Option<AppAction> = None;
-    let mut dragged_source: Option<(usize, egui::Pos2)> = None;
+    let mut dragged_source: Option<(usize, f32)> = None;
     let mut tab_rects: Vec<(usize, egui::Rect)> = Vec::new();
 
     let ws_root = state.workspace.as_ref().map(|ws| ws.root.clone());
@@ -832,6 +833,9 @@ pub(crate) fn render_tab_bar(ui: &mut egui::Ui, state: &mut AppState, action: &m
             .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysHidden)
             .id_salt("tab_scroll")
             .show(ui, |ui| {
+                let mut current_hovered_drop_x = None;
+                let mut dragging_ghost_info = None;
+
                 ui.horizontal(|ui| {
                     for (idx, doc) in state.open_documents.iter().enumerate() {
                         let is_active = state.active_doc_idx == Some(idx);
@@ -844,7 +848,7 @@ pub(crate) fn render_tab_bar(ui: &mut egui::Ui, state: &mut AppState, action: &m
                         };
                         let tooltip_path = relative_full_path(&doc.path, ws_root.as_deref());
 
-                        let resp = ui
+                        let (title_resp, close_resp) = ui
                             .push_id(format!("tab_{idx}"), |ui| {
                                 ui.set_max_width(if doc.is_pinned {
                                     PINNED_TAB_MAX_WIDTH
@@ -852,30 +856,97 @@ pub(crate) fn render_tab_bar(ui: &mut egui::Ui, state: &mut AppState, action: &m
                                     MAX_TAB_WIDTH
                                 });
                                 ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
-                                let inner_resp = ui.selectable_label(is_active, &title);
-                                ui.interact(
-                                    inner_resp.rect,
-                                    inner_resp.id,
-                                    egui::Sense::click_and_drag(),
-                                )
+
+                                let t_resp = ui.add(egui::Button::selectable(is_active, &title));
+                                let c_resp = ui.add(egui::Button::image_and_text(
+                                    crate::Icon::Close.ui_image(ui, crate::icon::IconSize::Small),
+                                    invisible_label("x"),
+                                ));
+                                (t_resp, c_resp)
                             })
                             .inner;
 
-                        tab_rects.push((idx, resp.rect));
-                        // Task 3.7: Only scroll when navigated via left/right buttons.
-                        if is_active && should_scroll {
-                            resp.scroll_to_me(Some(egui::Align::Center));
+                        let full_tab_rect = title_resp.rect.union(close_resp.rect);
+                        tab_rects.push((idx, full_tab_rect));
+
+                        let tab_interact = ui.interact(
+                            full_tab_rect,
+                            egui::Id::new("tab_interact").with(idx),
+                            egui::Sense::click_and_drag(),
+                        );
+
+                        let mut clicked_tab = tab_interact.clicked();
+                        if close_resp.clicked() {
+                            close_idx = Some(idx);
+                            clicked_tab = false;
                         }
-                        if resp.drag_stopped() {
-                            if let Some(pos) = ui.input(|i| i.pointer.hover_pos()) {
-                                dragged_source = Some((idx, pos));
+
+                        let is_being_dragged = ui.ctx().is_being_dragged(tab_interact.id);
+                        if is_being_dragged {
+                            if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
+                                let press_origin = ui
+                                    .input(|i| i.pointer.press_origin())
+                                    .unwrap_or(pointer_pos);
+                                let drag_offset = pointer_pos - press_origin;
+                                let ghost_rect = full_tab_rect.translate(drag_offset);
+
+                                // Save the ghost center X for the exact moment of drop!
+                                ui.memory_mut(|mem| {
+                                    mem.data.insert_temp(
+                                        egui::Id::new("drag_ghost_x").with(idx),
+                                        ghost_rect.center().x,
+                                    )
+                                });
+
+                                // Auto-scroll the horizontal scroll area to ensure the dragged tab is visible
+                                ui.scroll_to_rect(ghost_rect, None);
+
+                                // 1. Render ghost tab following the cursor
+                                egui::Area::new(egui::Id::new("tab_ghost").with(idx))
+                                    .fixed_pos(ghost_rect.min)
+                                    .order(egui::Order::Tooltip)
+                                    .show(ui.ctx(), |ui| {
+                                        ui.set_max_width(if doc.is_pinned {
+                                            PINNED_TAB_MAX_WIDTH
+                                        } else {
+                                            MAX_TAB_WIDTH
+                                        });
+                                        ui.style_mut().wrap_mode =
+                                            Some(egui::TextWrapMode::Truncate);
+
+                                        ui.horizontal(|ui| {
+                                            ui.spacing_mut().item_spacing.x = 0.0;
+                                            ui.add(egui::Button::selectable(is_active, &title));
+                                            ui.add(egui::Button::image_and_text(
+                                                crate::Icon::Close
+                                                    .ui_image(ui, crate::icon::IconSize::Small),
+                                                invisible_label("x"),
+                                            ));
+                                        });
+                                    });
+
+                                dragging_ghost_info = Some((ghost_rect, full_tab_rect.y_range()));
                             }
                         }
 
-                        let clicked = resp.clicked();
-                        let resp = resp.on_hover_text(&tooltip_path);
+                        // Task 3.7: Only scroll when navigated via left/right buttons.
+                        if is_active && should_scroll {
+                            tab_interact.scroll_to_me(Some(egui::Align::Center));
+                        }
 
-                        resp.context_menu(|ui| {
+                        // Retrieve the saved ghost_x purely from memory because pointer input might be cleared
+                        if tab_interact.drag_stopped() {
+                            if let Some(ghost_x) = ui.memory(|mem| {
+                                mem.data
+                                    .get_temp::<f32>(egui::Id::new("drag_ghost_x").with(idx))
+                            }) {
+                                dragged_source = Some((idx, ghost_x));
+                            }
+                        }
+
+                        let tab_interact = tab_interact.on_hover_text(&tooltip_path);
+
+                        tab_interact.context_menu(|ui| {
                             let i18n = crate::i18n::get();
 
                             if ui.button(&i18n.tab.close).clicked() {
@@ -917,20 +988,57 @@ pub(crate) fn render_tab_bar(ui: &mut egui::Ui, state: &mut AppState, action: &m
                             }
                         });
 
-                        if clicked && !is_active {
+                        if clicked_tab && !is_active {
                             tab_action = Some(AppAction::SelectDocument(doc.path.clone()));
                         }
 
-                        if ui
-                            .add(egui::Button::image_and_text(
-                                crate::Icon::Close.ui_image(ui, crate::icon::IconSize::Small),
-                                invisible_label("x"),
-                            ))
-                            .clicked()
-                        {
-                            close_idx = Some(idx);
-                        }
                         ui.add_space(TAB_INTER_ITEM_SPACING);
+                    }
+
+                    let mut drop_points = Vec::new();
+                    if !tab_rects.is_empty() {
+                        for i in 0..tab_rects.len() {
+                            if i == 0 {
+                                drop_points.push((0, tab_rects[i].1.left()));
+                            } else {
+                                let prev_right = tab_rects[i - 1].1.right();
+                                let current_left = tab_rects[i].1.left();
+                                drop_points.push((i, (prev_right + current_left) / 2.0));
+                            }
+                        }
+                        drop_points.push((tab_rects.len(), tab_rects.last().unwrap().1.right()));
+                    }
+
+                    if let Some((ghost_rect, y_range)) = dragging_ghost_info {
+                        let mut best_dist = f32::MAX;
+                        let mut best_x = None;
+
+                        for (_insert_idx, x) in &drop_points {
+                            let dist = (ghost_rect.center().x - x).abs();
+                            if dist < best_dist {
+                                best_dist = dist;
+                                best_x = Some(*x);
+                            }
+                        }
+                        if let Some(x) = best_x {
+                            current_hovered_drop_x = Some((x, y_range));
+                        }
+                    }
+
+                    // Draw animated (lerp) insertion marker
+                    if let Some((target_x, y_range)) = current_hovered_drop_x {
+                        let indicator_id = egui::Id::new("tab_drop_indicator");
+                        let animated_x = ui.ctx().animate_value_with_time(
+                            indicator_id,
+                            target_x,
+                            TAB_DROP_ANIMATION_TIME,
+                        );
+
+                        let stroke = egui::Stroke::new(
+                            TAB_DROP_INDICATOR_WIDTH,
+                            ui.visuals().selection.bg_fill,
+                        );
+                        ui.painter().vline(animated_x, y_range, stroke);
                     }
                 });
             });
@@ -993,14 +1101,35 @@ pub(crate) fn render_tab_bar(ui: &mut egui::Ui, state: &mut AppState, action: &m
         }
     });
 
-    if let Some((src_idx, drop_pos)) = dragged_source {
-        for (target_idx, rect) in &tab_rects {
-            if rect.contains(drop_pos) && src_idx != *target_idx {
-                tab_action = Some(AppAction::ReorderDocument {
-                    from: src_idx,
-                    to: *target_idx,
-                });
-                break;
+    if let Some((src_idx, ghost_center_x)) = dragged_source {
+        let mut drop_points = Vec::new();
+        if !tab_rects.is_empty() {
+            for i in 0..tab_rects.len() {
+                if i == 0 {
+                    drop_points.push((0, tab_rects[i].1.left()));
+                } else {
+                    let prev_right = tab_rects[i - 1].1.right();
+                    let current_left = tab_rects[i].1.left();
+                    drop_points.push((i, (prev_right + current_left) / 2.0));
+                }
+            }
+            drop_points.push((tab_rects.len(), tab_rects.last().unwrap().1.right()));
+        }
+
+        let mut best_dist = f32::MAX;
+        let mut best_insert_idx = None;
+
+        for (insert_idx, x) in drop_points {
+            let dist = (ghost_center_x - x).abs();
+            if dist < best_dist {
+                best_dist = dist;
+                best_insert_idx = Some(insert_idx);
+            }
+        }
+
+        if let Some(to) = best_insert_idx {
+            if src_idx != to && src_idx + 1 != to {
+                tab_action = Some(AppAction::ReorderDocument { from: src_idx, to });
             }
         }
     }

--- a/openspec/changes/archive/2026-03-26-v0-7-3-tab-ux-improvements/tasks.md
+++ b/openspec/changes/archive/2026-03-26-v0-7-3-tab-ux-improvements/tasks.md
@@ -60,73 +60,14 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 
 ---
 
-## 4. タブグルーピング機能の実装
-
-- [ ] 4.1 `TabGroup { id, name, color, tab_ids }` データモデルを定義
-- [ ] 4.2 プリセット8色（赤・橙・黄・緑・青・紫・ピンク・グレー）の定数定義
-- [ ] 4.3 コンテキストメニューに「グループに追加」→「新しいグループ」「既存グループ名」を追加
-- [ ] 4.4 グループ名インライン編集UIの実装
-- [ ] 4.5 グループの色変更UI（プリセット選択 + ColorPicker）の実装
-- [ ] 4.6 「グループを解除」の実装（タブは閉じない）
-- [ ] 4.7 グループ情報のワークスペース単位永続化（設定ファイルへの読み書き）
-- [ ] 4.8 ワークスペース切り替え時のグループ状態切り替え実装
-- [ ] 4.9 グループのバージョンフィールドを設定スキーマに追加（後方互換性）
-- [ ] 4.10 グループは伸縮してすることで複数のタブを表示・非表示できる。
-- [ ] 4.11 ユーザーへのUIスナップショット（画像等）の提示および動作報告
-- [ ] 4.12 ユーザーからのフィードバックに基づくUIの微調整および改善実装
-
-### Definition of Done (DoD)
-
-- [ ] グループの作成・削除・色変更・タブ追加が動作する
-- [ ] アプリ再起動後にグループが復元される
-- [ ] `make check` が exit code 0 で通過
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
-
 ---
 
-## 5. セッション復元（タブ履歴永続化）の実装
+## 4. Final Verification & Release Work
 
-- [ ] 5.1 `SessionState { tabs: Vec<TabEntry>, active_tab: Option<TabId> }` を定義
-- [ ] 5.2 アプリ終了時に `last_session.json` をアプリデータディレクトリに書き込む処理を追加
-- [ ] 5.3 アプリ起動時に `last_session.json` を読み込み、タブを復元する処理を追加
-- [ ] 5.4 ファイル破損時のフォールバック（エラーを無視してデフォルト起動）を実装
-- [ ] 5.5 設定画面に「前回のタブを復元する」ON/OFFトグルを追加
-- [ ] 5.6 ユーザーへのUIスナップショット（画像等）の提示および動作報告
-- [ ] 5.7 ユーザーからのフィードバックに基づくUIの微調整および改善実装
-
-### Definition of Done (DoD)
-
-- [ ] 再起動後に前回開いていたタブが復元される
-- [ ] 設定でOFF時は復元されない
-- [ ] `make check` が exit code 0 で通過
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
-
----
-
-## 6. ピン留め機能の改善
-
-- [ ] 6.1 ピン留め中のタブの閉じるボタン（×）を非表示にする
-- [ ] 6.2 ピン留め中でもホバー時にタイトルをツールチップで表示する
-- [ ] 6.3 ショートカットキーでのタブ閉じ操作がピン留めタブに無効になるよう実装
-- [ ] 6.4 コンテキストメニューの「ピン留め解除」実装を確認・修正（解除後に×ボタン再表示）
-- [ ] 6.5 ユーザーへのUIスナップショット（画像等）の提示および動作報告
-- [ ] 6.6 ユーザーからのフィードバックに基づくUIの微調整および改善実装
-
-### Definition of Done (DoD)
-
-- [ ] ピン留め中のタブがコンテキストメニューなしで削除できないことを確認
-- [ ] ピン留め中にタイトルがツールチップで表示される
-- [ ] `make check` が exit code 0 で通過
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
-
----
-
-## 7. Final Verification & Release Work
-
-- [ ] 7.1 Execute self-review using `docs/coding-rules.ja.md` and `.agents/skills/self-review/SKILL.md` (Check for missing version updates in each file)
-- [ ] 7.2 Ensure `make check` passes with exit code 0
-- [ ] 7.3 Merge the intermediate base branch (derived originally from master) into the `master` branch
-- [ ] 7.4 Create a PR targeting `master`
-- [ ] 7.5 Merge into master (※ `--admin` is permitted)
-- [ ] 7.6 Execute release tagging and creation using `.agents/skills/release_workflow/SKILL.md` for `0.7.3`
-- [ ] 7.7 Archive this change by leveraging OpenSpec skills like `/opsx-archive`
+- [ ] 4.1 Execute self-review using `docs/coding-rules.ja.md` and `.agents/skills/self-review/SKILL.md` (Check for missing version updates in each file)
+- [ ] 4.2 Ensure `make check` passes with exit code 0
+- [ ] 4.3 Merge the intermediate base branch (derived originally from master) into the `master` branch
+- [ ] 4.4 Create a PR targeting `master`
+- [ ] 4.5 Merge into master (※ `--admin` is permitted)
+- [ ] 4.6 Execute release tagging and creation using `.agents/skills/release_workflow/SKILL.md` for `0.7.3`
+- [ ] 4.7 Archive this change by leveraging OpenSpec skills like `/opsx-archive`

--- a/openspec/changes/archive/2026-03-26-v0-7-3-tab-ux-improvements/tasks.md
+++ b/openspec/changes/archive/2026-03-26-v0-7-3-tab-ux-improvements/tasks.md
@@ -46,17 +46,17 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 
 ## 3. タブ双方向移動の修正とUI/UX改善
 
-- [ ] 3.1 左→右ドラッグ移動が機能しない原因を特定（配列境界チェック）
-- [ ] 3.2 双方向ドラッグ移動のロジックを修正
-- [ ] 3.3 移動中のスナップアニメーション（egui `lerp`）を統一実装
-- [ ] 3.4 ユーザーへのUIスナップショット（動画等）の提示および動作報告
-- [ ] 3.5 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+- [x] 3.1 左→右ドラッグ移動が機能しない原因を特定（配列境界チェック）
+- [x] 3.2 双方向ドラッグ移動のロジックを修正
+- [x] 3.3 移動中のスナップアニメーション（egui `lerp`）を統一実装
+- [x] 3.4 ユーザーへのUIスナップショット（動画等）の提示および動作報告
+- [x] 3.5 ユーザーからのフィードバックに基づくUIの微調整および改善実装
 
 ### Definition of Done (DoD)
 
-- [ ] 左→右・右→左双方向のドラッグ移動が正常動作する
-- [ ] `make check` が exit code 0 で通過
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+- [x] 左→右・右→左双方向のドラッグ移動が正常動作する
+- [x] `make check` が exit code 0 で通過
+- [x] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ---
 
@@ -71,8 +71,9 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 - [ ] 4.7 グループ情報のワークスペース単位永続化（設定ファイルへの読み書き）
 - [ ] 4.8 ワークスペース切り替え時のグループ状態切り替え実装
 - [ ] 4.9 グループのバージョンフィールドを設定スキーマに追加（後方互換性）
-- [ ] 4.10 ユーザーへのUIスナップショット（画像等）の提示および動作報告
-- [ ] 4.11 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+- [ ] 4.10 グループは伸縮してすることで複数のタブを表示・非表示できる。
+- [ ] 4.11 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [ ] 4.12 ユーザーからのフィードバックに基づくUIの微調整および改善実装
 
 ### Definition of Done (DoD)
 

--- a/openspec/changes/v0-7-5-settings-and-defaults/tasks.md
+++ b/openspec/changes/v0-7-5-settings-and-defaults/tasks.md
@@ -1,0 +1,148 @@
+## Definition of Ready (DoR)
+
+- [ ] proposal.md, design.md, specs が揃っていること
+- [ ] 対象バージョン 0.7.4 のブランチ戦略が確認されていること
+- [ ] ComboBox共通化対象の2箇所を実装前に再確認すること
+
+## Branch Rule
+
+Tasks Grouped by ## = Adhere unconditionally to the branching standard defined in the `/openspec-branching` workflow (`.agents/workflows/openspec-branching.md`) throughout your implementation sessions.
+
+---
+
+## 1. 設定画面プルダウンの共通UI統一
+
+### 対象箇所（実装前に再確認・追加洗い出しを行うこと）
+
+| No | ファイル | 行 | ID | 説明 |
+|---|---|---|---|---|
+| 1 | `settings_window.rs` | L883 | `update_interval` | 更新間隔選択ComboBox |
+| 2 | `shell_ui.rs` | L2185 | `terms_lang_select` | 利用規約言語選択ComboBox |
+
+- [ ] 1.1 全ソースを検索し、上記以外の `egui::ComboBox` 使用箇所がないことを確認（洗い出しを完了させる）
+- [ ] 1.2 previewセッションで開発した共通UIパターンを参考に `add_styled_combobox` 汎用関数を実装
+- [ ] 1.3 `settings_window.rs` L883 の `update_interval` ComboBoxを共通コンポーネントに置き換え
+- [ ] 1.4 `shell_ui.rs` L2185 の `terms_lang_select` ComboBoxを共通コンポーネントに置き換え
+- [ ] 1.5 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [ ] 1.6 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+
+### Definition of Done (DoD)
+
+- [ ] 全対象箇所のアイコン・文字が上下中央に揃っていることをスナップショットで確認
+- [ ] `egui::ComboBox` の直接使用が設定画面から撤廃されている
+- [ ] `make check` が exit code 0 で通過
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 2. システムデフォルト挙動の設定化
+
+- [ ] 2.1 設定画面に追加する対象の洗い出しと確定（実装前に以下の候補から優先度付け）
+  - ※セッション復元ON/OFFの**設定UI**はv0.7.3で実装済みであること。本タスクではv0.7.3に実装した設定ロジックを参照する形で統合する（重複実装不可）
+  - タブを閉じる際の確認ダイアログ（変更済みファイルのみ）← 本changeで新規実装
+  - 新規ファイルのデフォルト拡張子 ← 本changeで新規実装
+- [ ] 2.2 `AppBehavior` struct を `katana-platform/src/settings.rs` に追加（全フィールドに `#[serde(default)]`）
+- [ ] 2.3 設定画面に「動作」セクションを追加し、各設定のUI（トグル・テキスト入力等）を実装
+- [ ] 2.4 各デフォルト挙動をアプリのロジックに接続
+- [ ] 2.5 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [ ] 2.6 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+
+### Definition of Done (DoD)
+
+- [ ] 設定画面からシステムデフォルト挙動を変更でき、再起動後も反映されていること
+- [ ] 旧設定ファイルでも `#[serde(default)]` でエラーなく起動すること
+- [ ] `make check` が exit code 0 で通過
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 3. カスタムテーマの名前付き保存
+
+- [ ] 3.1 `CustomTheme { name: String, colors: ThemeColors }` struct を定義
+- [ ] 3.2 設定スキーマに `custom_themes: Vec<CustomTheme>`（最大10件）を追加
+- [ ] 3.3 「名前をつけて保存」UIの実装（現在のカスタム色をテーマとして保存）
+- [ ] 3.4 カスタムテーマプリセット一覧に保存済みテーマを表示する実装
+- [ ] 3.5 カスタムテーマの削除UI（右クリックメニューまたは削除ボタン）
+- [ ] 3.6 適用中のカスタムテーマが削除された場合のデフォルトへのフォールバック処理
+- [ ] 3.7 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [ ] 3.8 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+
+### Definition of Done (DoD)
+
+- [ ] カスタムテーマを保存・選択・削除できること
+- [ ] アプリ再起動後にカスタムテーマが維持されること
+- [ ] `make check` が exit code 0 で通過
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 4. タブグルーピング機能の実装
+
+- [ ] 4.1 `TabGroup { id, name, color, tab_ids }` データモデルを定義
+- [ ] 4.2 プリセット8色（赤・橙・黄・緑・青・紫・ピンク・グレー）の定数定義
+- [ ] 4.3 コンテキストメニューに「グループに追加」→「新しいグループ」「既存グループ名」を追加
+- [ ] 4.4 グループ名インライン編集UIの実装
+- [ ] 4.5 グループの色変更UI（プリセット選択 + ColorPicker）の実装
+- [ ] 4.6 「グループを解除」の実装（タブは閉じない）
+- [ ] 4.7 グループ情報のワークスペース単位永続化（設定ファイルへの読み書き）
+- [ ] 4.8 ワークスペース切り替え時のグループ状態切り替え実装
+- [ ] 4.9 グループのバージョンフィールドを設定スキーマに追加（後方互換性）
+- [ ] 4.10 グループは伸縮してすることで複数のタブを表示・非表示できる。
+- [ ] 4.11 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [ ] 4.12 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+
+### Definition of Done (DoD)
+
+- [ ] グループの作成・削除・色変更・タブ追加が動作する
+- [ ] アプリ再起動後にグループが復元される
+- [ ] `make check` が exit code 0 で通過
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 5. セッション復元（タブ履歴永続化）の実装
+
+- [ ] 5.1 `SessionState { tabs: Vec<TabEntry>, active_tab: Option<TabId> }` を定義
+- [ ] 5.2 アプリ終了時に `last_session.json` をアプリデータディレクトリに書き込む処理を追加
+- [ ] 5.3 アプリ起動時に `last_session.json` を読み込み、タブを復元する処理を追加
+- [ ] 5.4 ファイル破損時のフォールバック（エラーを無視してデフォルト起動）を実装
+- [ ] 5.5 設定画面に「前回のタブを復元する」ON/OFFトグルを追加
+- [ ] 5.6 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [ ] 5.7 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+
+### Definition of Done (DoD)
+
+- [ ] 再起動後に前回開いていたタブが復元される
+- [ ] 設定でOFF時は復元されない
+- [ ] `make check` が exit code 0 で通過
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 6. ピン留め機能の改善
+
+- [ ] 6.1 ピン留め中のタブの閉じるボタン（×）を非表示にする
+- [ ] 6.2 ピン留め中でもホバー時にタイトルをツールチップで表示する
+- [ ] 6.3 ショートカットキーでのタブ閉じ操作がピン留めタブに無効になるよう実装
+- [ ] 6.4 コンテキストメニューの「ピン留め解除」実装を確認・修正（解除後に×ボタン再表示）
+- [ ] 6.5 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [ ] 6.6 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+
+### Definition of Done (DoD)
+
+- [ ] ピン留め中のタブがコンテキストメニューなしで削除できないことを確認
+- [ ] ピン留め中にタイトルがツールチップで表示される
+- [ ] `make check` が exit code 0 で通過
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 7. Final Verification & Release Work
+
+- [ ] 7.1 Execute self-review using `docs/coding-rules.ja.md` and `.agents/skills/self-review/SKILL.md` (Check for missing version updates in each file)
+- [ ] 7.2 Ensure `make check` passes with exit code 0
+- [ ] 7.3 Merge the intermediate base branch (derived originally from master) into the `master` branch
+- [ ] 7.4 Create a PR targeting `master`
+- [ ] 7.5 Merge into master (※ `--admin` is permitted)
+- [ ] 7.6 Execute release tagging and creation using `.agents/skills/release_workflow/SKILL.md` for `0.7.4`
+- [ ] 7.7 Archive this change by leveraging OpenSpec skills like `/opsx-archive`


### PR DESCRIPTION
## 概要
手違いにより v0.7.3 リリースに不足していた Task 3 （タブ移動改善等）の未プッシュコミットを救出し、masterへ再統合します。

## 対応内容
- タブ双方向移動の修正
- ドラッグ移動時のスクロール追従
- タスクファイル（tasks.md）の後送対応

これらをマージ後、再度 `make release VERSION=0.7.3` を実行します。