### PR TITLE
feat: Update Install Hardening (Task 3)

### DIFF
--- a/crates/katana-core/src/update/installer.rs
+++ b/crates/katana-core/src/update/installer.rs
@@ -28,8 +28,10 @@ where
         .file_name()
         .unwrap_or_else(|| std::ffi::OsStr::new("KatanA.app"));
     let extracted_app_path = extract_dir.join(app_name);
-    if !extracted_app_path.exists() {
-        anyhow::bail!("Extracted update does not contain the expected application bundle");
+
+    // Bundle verification: Check if it looks like a valid macOS App Bundle
+    if !extracted_app_path.exists() || !extracted_app_path.join("Contents/Info.plist").exists() {
+        anyhow::bail!("Extracted update does not contain a valid application bundle");
     }
 
     let script_path = temp_dir.path().join("relauncher.sh");
@@ -93,10 +95,32 @@ if command -v brew >/dev/null 2>&1; then
         brew untap HiroyukiFuruno/katana || true
     fi
 fi
-rm -rf "{target}"
-mv "{extracted}" "{target}"
-xattr -cr "{target}"
+
+TARGET_BAK="{target}.bak"
+rm -rf "$TARGET_BAK"
+
+if [ -d "{target}" ]; then
+    echo "Backing up existing installation..."
+    mv "{target}" "$TARGET_BAK"
+fi
+
+if ! mv "{extracted}" "{target}"; then
+    echo "Swap failed! Rolling back..."
+    osascript -e 'display alert "Update Failed" message "Could not complete the application update. The original version has been restored." as critical' || true
+    rm -rf "{target}"
+    
+    if [ -d "$TARGET_BAK" ]; then
+        mv "$TARGET_BAK" "{target}"
+    fi
+    
+    open "{target}" || true
+    rm -rf "{temp_dir}"
+    exit 1
+fi
+
+xattr -cr "{target}" || true
 open "{target}"
+rm -rf "$TARGET_BAK"
 rm -rf "{temp_dir}"
 "#,
         target = target_app.display(),
@@ -124,12 +148,15 @@ mod tests {
         assert!(script_path.exists());
 
         let content = std::fs::read_to_string(&script_path).unwrap();
-        assert!(content.contains(&format!("rm -rf \"{}\"", target_path.display())));
+        assert!(content.contains(&format!("TARGET_BAK=\"{}.bak\"", target_path.display())));
+        assert!(content.contains(&format!("mv \"{}\" \"$TARGET_BAK\"", target_path.display())));
         assert!(content.contains(&format!(
-            "mv \"{}\" \"{}\"",
+            "if ! mv \"{}\" \"{}\"; then",
             extracted_path.display(),
             target_path.display()
         )));
+        assert!(content.contains("display alert \"Update Failed\""));
+        assert!(content.contains("Swap failed! Rolling back..."));
         assert!(content.contains("brew uninstall --cask katana-desktop --force"));
         assert!(content.contains(&format!("xattr -cr \"{}\"", target_path.display())));
         assert!(content.contains(&format!("rm -rf \"{}\"", temp_dir.path().display())));
@@ -163,6 +190,9 @@ mod tests {
                 let options =
                     SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
                 zip.add_directory("KatanA.app/", options).unwrap();
+                zip.add_directory("KatanA.app/Contents/", options).unwrap();
+                zip.start_file("KatanA.app/Contents/Info.plist", options)
+                    .unwrap();
                 zip.finish().unwrap();
             }
 
@@ -207,6 +237,8 @@ mod tests {
                 let options =
                     SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
                 zip.add_directory("Wrong.app/", options).unwrap();
+                zip.start_file("Wrong.app/Contents/Info.plist", options)
+                    .unwrap();
                 zip.finish().unwrap();
             }
 
@@ -223,7 +255,7 @@ mod tests {
         assert!(res.is_err());
         assert_eq!(
             res.unwrap_err().to_string(),
-            "Extracted update does not contain the expected application bundle"
+            "Extracted update does not contain a valid application bundle"
         );
     }
 }

--- a/openspec/changes/v0-8-7-runtime-and-delivery-hardening/tasks.md
+++ b/openspec/changes/v0-8-7-runtime-and-delivery-hardening/tasks.md
@@ -35,22 +35,22 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 ### Definition of Done (DoD)
 
 - [x] settings 保存は atomic write になり、破損時と保存失敗時の UI/log 振る舞いが spec を満たす
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+- [x] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ## 3. Update Install Hardening
 
 ### Definition of Ready (DoR)
 
-- [ ] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
-- [ ] Base branch is synced, and a new branch is explicitly created for this task.
+- [x] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
+- [x] Base branch is synced, and a new branch is explicitly created for this task.
 
-- [ ] 3.1 update relaunch script を staged swap + rollback 方式に置き換える
-- [ ] 3.2 `prepare_update` と relaunch path に bundle 検証、swap failure handling、actionable error message を追加する
-- [ ] 3.3 更新準備失敗と swap failure を検証する自動テストを追加する
+- [x] 3.1 update relaunch script を staged swap + rollback 方式に置き換える
+- [x] 3.2 `prepare_update` と relaunch path に bundle 検証、swap failure handling、actionable error message を追加する
+- [x] 3.3 更新準備失敗と swap failure を検証する自動テストを追加する
 
 ### Definition of Done (DoD)
 
-- [ ] destructive replacement を廃止し、更新失敗時でも既存アプリの可用性が保たれる
+- [x] destructive replacement を廃止し、更新失敗時でも既存アプリの可用性が保たれる
 - [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ## 4. Release Pipeline Consistency


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)
- Update Install Hardening (Task 3) の実装完了。
- Application Update時の既存アプリ直接置換(`rm -rf` + `mv`)という破壊的更新を廃止し、安全なStaged Swapと、エラー時の確実なロールバック処理を追加しました。

## 対応内容 (Changes Made)
- `katana-core/src/update/installer.rs`: `relauncher.sh` の生成スクリプトを、まずは`.bak`への退避から行うように刷新。
- 新アップデートバンドル展開失敗時に`.bak`からリストアするフォールバックフローを追加。
- 失敗時に `osascript` でユーザーフレンドリーな Actionable Error Alert を表示する処理をスクリプト内に組み込み。
- Update Bundle に `Contents/Info.plist` が存在するかどうかの最低限の整合性検証を `prepare_update` に実装。
- 上記を担保する自動テスト（スクリプトロジックのアサーション等）の追加。

## 影響範囲 (Impact Scope)
- アップデートインストール時の振る舞い (`katana-core::update` モジュール) のみ。

## 動作確認結果 (Verification Results)
- `cargo fmt && make check` 全てPASS。
- 意図した通り、バンドル破損（Info.plist不在）を検知して正しくエラーが返ることを単体テストで確認。
- ローカル環境の自動テストカバレッジ維持。
