### PR TITLE
docs: Sync runbook and maintainer handoff (Task 4)

### DIFF
--- a/openspec/changes/v0-8-8-vendor-subtree/tasks.md
+++ b/openspec/changes/v0-8-8-vendor-subtree/tasks.md
@@ -71,17 +71,17 @@
 
 ### 着手条件 (DoR)
 
-- [ ] 直前の task が self-review、recovery（必要時）、PR 作成、merge、branch 削除まで含めて完了している
-- [ ] base branch が同期済みであり、この task 用の新しい branch が明示的に作成されている
+- [x] 直前の task が self-review、recovery（必要時）、PR 作成、merge、branch 削除まで含めて完了している
+- [x] base branch が同期済みであり、この task 用の新しい branch が明示的に作成されている
 
-- [ ] 4.1 `vendor/README.md` として maintainer runbook を追加し、subtree remote、prefix、互換 revision 方針、patch layer ルールを記述する
-- [ ] 4.2 今後の subtree pull に必要な command と verification 手順を文書化する
-- [ ] 4.3 互換性前提が変わった場合は OpenSpec artifact を先に更新する stop-and-correct rule を文書化する
+- [x] 4.1 `vendor/README.md` として maintainer runbook を追加し、subtree remote、prefix、互換 revision 方針、patch layer ルールを記述する
+- [x] 4.2 今後の subtree pull に必要な command と verification 手順を文書化する
+- [x] 4.3 互換性前提が変わった場合は OpenSpec artifact を先に更新する stop-and-correct rule を文書化する
 
 ### 完了条件 (DoD)
 
-- [ ] 別の AI agent や maintainer が、この会話に頼らず subtree 更新と再検証を実行できる
-- [ ] runbook (`vendor/README.md`) に steady-state sync 手順と artifact 修正への escalation path の両方が記載されている
+- [x] 別の AI agent や maintainer が、この会話に頼らず subtree 更新と再検証を実行できる
+- [x] runbook (`vendor/README.md`) に steady-state sync 手順と artifact 修正への escalation path の両方が記載されている
 - [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) を実行し、包括的な delivery 手順（Self-review、Commit、PR Creation、Merge）を完了する
 
 ---

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,96 @@
+# Katana Vendor Subtrees
+
+This directory contains vendored subtrees that Katana depends on and patches
+locally.
+Specifically, `egui_commonmark` and its related crates have been incorporated as
+a Git `subtree` to maintain a clear boundary between the upstream code and
+Katana-specific customizations.
+
+## Subtree Repository Information
+
+- **Upstream Repository**: `https://github.com/lampsitter/egui_commonmark`
+- **Subtree Prefix**: `vendor/egui_commonmark_upstream`
+- **Current Pinned Upstream Revision**: `v0.22.0`
+- **Related Cargo crates**: `egui_commonmark`, `egui_commonmark_backend`,
+  `egui_commonmark_macros`
+
+## Patch Layer Policy
+
+To support Katana's unique features without losing track of upstream logic,
+we strictly enforce a two-layered structure:
+
+1. **Base Layer**: The raw `git subtree` pull from the upstream repository.
+2. **Patch Layer**: The Katana-specific file overrides applied directly over
+   the subtree output.
+
+When upgrading upstream versions, **never** manually copy files over. Always
+use the Git Subtree commands to perform clean merges, resolving conflicts
+against the Katana patch layer.
+
+## How to Perform a Subtree Sync (Pull)
+
+If a future maintainer or AI agent needs to update the subtree to a newer
+upstream version, follow these exact steps to preserve history and apply
+conflict resolution cleanly:
+
+### 1. Verification of Compatibility Assumptions
+
+Before pulling, confirm that the new upstream version remains compatible with
+Katana's core dependencies (e.g., `egui` versions).
+If the upstream version requires `egui` `0.34`, but Katana is on `0.33`,
+**DO NOT PROCEED**.
+See the "Stop-and-Correct Rule" below.
+
+### 2. Pulling the Subtree
+
+From the repository root, run the subtree pull command targeting the new tag
+or branch:
+
+```bash
+git subtree pull --prefix=vendor/egui_commonmark_upstream \
+https://github.com/lampsitter/egui_commonmark \
+<UPSTREAM_TAG_OR_BRANCH> --squash
+```
+
+*Note: The `--squash` flag is mandatory to prevent importing the entire upstream
+Git history into the Katana repository footprint.*
+
+### 3. Conflict Resolution (Patch Re-application)
+
+Git subtree merges the upstream baseline into our directory.
+If upstream changed code that Katana has patched, you will experience a
+merge conflict. You must manually resolve these conflicts, carefully combining
+upstream bug fixes with Katana's custom behavior overrides (such as
+`extract_task_list_spans`, rendering integrations, and SVG icon paths).
+
+### 4. Verification
+
+After resolution, you must prove zero regressions:
+
+```bash
+make check
+```
+
+Because the test suite includes deep visual and structural markdown regressions,
+standard tests adequately enforce that rendering integrations have survived
+the subtree merge.
+
+## 🛑 Stop-and-Correct Rule
+
+If you discover that an upstream sync requires architectural changes across
+Katana, or breaks fundamental dependency bounds (e.g., upgrading `egui` to
+a breaking major version), you **MUST NOT** proceed with the sync
+implementation immediately.
+
+You must follow the **Stop-and-Correct Rule**:
+
+1. Pause the sync operation.
+2. Fall back to `/openspec-propose` or utilize an explicit workflow
+   (`v0-x-y-some-migration`) to create a new, formal OpenSpec feature proposal
+   (`proposal.md`, `design.md`, `tasks.md`).
+3. Document *why* the compatibility premise changed and define how the KatanA
+   system must migrate before doing the raw sync.
+4. Only implement the sync as a documented step in the new OpenSpec `tasks.md`.
+
+*Failure to observe the Stop-and-Correct Rule risks undocumented configuration
+drift and broken integrations taking root in `master`.*


### PR DESCRIPTION
Adds documentation for maintainers detailing the Git subtree sync process and Stop-and-Correct rules for future patching.