### PR TITLE
AST LinterによるSVG資産の正当性検証ルールの実装とファイルツリーのアイコン修正

### DIFF
--- a/assets/icons/feather/system/bug.svg
+++ b/assets/icons/feather/system/bug.svg
@@ -1,1 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-alert-octagon"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#FFFFFF"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 20v-9" />
+  <path d="M14 7a4 4 0 0 1 4 4v3a6 6 0 0 1-12 0v-3a4 4 0 0 1 4-4z" />
+  <path d="M14.12 3.88 16 2" />
+  <path d="M21 21a4 4 0 0 0-3.81-4" />
+  <path d="M21 5a4 4 0 0 1-3.55 3.97" />
+  <path d="M22 13h-4" />
+  <path d="M3 21a4 4 0 0 1 3.81-4" />
+  <path d="M3 5a4 4 0 0 0 3.55 3.97" />
+  <path d="M6 13H2" />
+  <path d="m8 2 1.88 1.88" />
+  <path d="M9 7.13V6a3 3 0 1 1 6 0v1.13" />
+</svg>

--- a/assets/icons/katana/files/markdown.svg
+++ b/assets/icons/katana/files/markdown.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M14 4.5l-2-2L3 11.5V13h1.5L14 4.5z"/>
-  <path d="M10 2.5l3 3"/>
-  <path d="M14 14H2"/>
+  <rect x="1" y="3" width="14" height="10" rx="2" />
+  <path d="M4 10V6l2 2 2-2v4" />
+  <path d="M12 9l-1.5 1.5L9 9m1.5 -3v4.5" />
 </svg>

--- a/crates/katana-linter/src/rules/domains/assets/icons_sync.rs
+++ b/crates/katana-linter/src/rules/domains/assets/icons_sync.rs
@@ -182,7 +182,7 @@ impl IconsSyncOps {
             "view/pan_down.svg", "view/pan_right.svg", "ui/expand_all.svg", "ui/collapse_all.svg",
             "ui/close.svg", "ui/remove.svg", "ui/copy.svg", "system/history.svg", "system/hourglass.svg",
             "system/recent.svg", "system/github.svg", "layout/swap_horizontal.svg",
-            "layout/swap_vertical.svg", "files/explorer.svg",
+            "layout/swap_vertical.svg", "files/explorer.svg", "system/bug.svg",
         ]
     }
 }

--- a/crates/katana-linter/src/rules/domains/assets/icons_sync.rs
+++ b/crates/katana-linter/src/rules/domains/assets/icons_sync.rs
@@ -1,5 +1,6 @@
 use crate::Violation;
 use crate::utils::LinterFileOps;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
@@ -12,7 +13,7 @@ impl IconsSyncOps {
         let mut violations = Vec::new();
 
         let types_rs_path = workspace_root.join("crates/katana-ui/src/icon/types.rs");
-        let icons_dir = workspace_root.join("assets/icons/katana");
+        let icons_dir = workspace_root.join("assets/icons");
 
         if !types_rs_path.exists() || !icons_dir.exists() {
             return violations;
@@ -23,51 +24,142 @@ impl IconsSyncOps {
             Err(_) => return violations,
         };
 
-        let mut registered_icons = std::collections::HashSet::new();
+        /* WHY: 1. Extract registered icons from define_icons! */
+        let mut registered_icons = HashSet::new();
         for line in content.lines() {
             Self::extract_registered_icon(line, &mut registered_icons);
         }
 
-        let svg_files = LinterFileOps::collect_files_by_extension(&icons_dir, "svg");
-        let mut actual_icons = std::collections::HashSet::new();
-
-        for svg_path in svg_files {
-            let Ok(rel_path) = svg_path.strip_prefix(&icons_dir) else {
-                continue;
-            };
-
-            let mut path_str = rel_path.to_string_lossy().to_string();
-            if path_str.ends_with(".svg") {
-                path_str.truncate(path_str.len() - EXTENSION_LEN);
-            }
-            /* WHY: Standardize path separators for cross-platform robustness */
-            let normalized_path = path_str.replace('\\', "/");
-            actual_icons.insert(normalized_path.clone());
-
-            if !registered_icons.contains(&normalized_path) {
-                violations.push(Violation {
-                    file: svg_path.clone(),
-                    line: 1,
-                    column: 0,
-                    message: format!(
-                        "SVG file found but not registered in types.rs `define_icons!` macro: {}",
-                        normalized_path
-                    ),
-                });
+        /* WHY: 2. Discover theme packs */
+        let mut theme_packs = Vec::new();
+        let Ok(entries) = fs::read_dir(&icons_dir) else {
+            return violations;
+        };
+        for entry in entries.flatten() {
+            if entry.file_type().unwrap().is_dir() {
+                theme_packs.push(entry.file_name().to_string_lossy().to_string());
             }
         }
 
+        /* WHY: We will store actual_icons per theme pack to check sync */
+        let mut per_theme_icons: HashMap<String, HashSet<String>> = HashMap::new();
+        /* WHY: For duplicates check */
+        let mut file_contents: HashMap<String, Vec<String>> = HashMap::new();
+
+        let whitelist = Self::get_duplicate_whitelist();
+
+        for theme in &theme_packs {
+            let theme_dir = icons_dir.join(theme);
+            let svg_files = LinterFileOps::collect_files_by_extension(&theme_dir, "svg");
+            let mut actual_icons = HashSet::new();
+
+            for svg_path in svg_files {
+                let Ok(rel_path) = svg_path.strip_prefix(&theme_dir) else {
+                    continue;
+                };
+
+                let mut path_str = rel_path.to_string_lossy().to_string();
+                if path_str.ends_with(".svg") {
+                    path_str.truncate(path_str.len() - EXTENSION_LEN);
+                }
+                let normalized_path = path_str.replace('\\', "/");
+                actual_icons.insert(normalized_path.clone());
+
+                /* WHY: Task 5.3: Detect unregistered SVGs */
+                if !registered_icons.contains(&normalized_path) {
+                    violations.push(Violation {
+                        file: svg_path.clone(),
+                        line: 1,
+                        column: 0,
+                        message: format!(
+                            "SVG file found but not registered in types.rs `define_icons!` macro: {}",
+                            normalized_path
+                        ),
+                    });
+                }
+
+                /* WHY: Collect content for duplicate detection */
+                let Ok(content) = fs::read(&svg_path) else {
+                    continue;
+                };
+                use std::collections::hash_map::DefaultHasher;
+                use std::hash::{Hash, Hasher};
+                let mut hasher = DefaultHasher::new();
+                content.hash(&mut hasher);
+                let hash = format!("{:x}", hasher.finish());
+
+                file_contents
+                    .entry(hash)
+                    .or_default()
+                    .push(svg_path.to_string_lossy().to_string());
+            }
+            per_theme_icons.insert(theme.clone(), actual_icons);
+        }
+
+        /* WHY: Ensure all registered icons exist in ALL theme packs */
         for (i, line) in content.lines().enumerate() {
-            Self::check_macro_registration(line, i, &types_rs_path, &actual_icons, &mut violations);
+            let Some(pos) = line.find("=>") else {
+                continue;
+            };
+            let Some(start) = line[pos..].find('"') else {
+                continue;
+            };
+            let Some(end) = line[pos + start + 1..].find('"') else {
+                continue;
+            };
+            let icon_path = &line[pos + start + 1..pos + start + 1 + end];
+
+            for theme in &theme_packs {
+                let Some(actual_icons) = per_theme_icons.get(theme) else {
+                    continue;
+                };
+                if !actual_icons.contains(icon_path) {
+                    violations.push(Violation {
+                        file: types_rs_path.clone(),
+                        line: i + 1,
+                        column: pos + start,
+                        message: format!(
+                            "Icon `{}` is registered in marco, but missing from theme pack `{}`.",
+                            icon_path, theme
+                        ),
+                    });
+                }
+            }
+        }
+
+        /* WHY: Duplicate SVG detection */
+        for (_hash, paths) in file_contents {
+            if paths.len() <= 1 {
+                continue;
+            }
+            /* WHY: Check if ALL these paths are in the whitelist */
+            let all_whitelisted = paths
+                .iter()
+                .all(|p| whitelist.iter().any(|&w| p.contains(w)));
+
+            if !all_whitelisted {
+                let mut message = "Duplicate SVGs detected (identical contents). ".to_string();
+                message.push_str(
+                    "If intentional, add to the whitelist. Otherwise, unique icons are required. ",
+                );
+                message.push_str(
+                    "See `.gemini/antigravity/skills/svg-icon-management/SKILL.md` for policy. ",
+                );
+                message.push_str(&format!("Duplicates: {:?}", paths));
+
+                violations.push(Violation {
+                    file: Path::new(&paths[0]).to_path_buf(),
+                    line: 1,
+                    column: 0,
+                    message,
+                });
+            }
         }
 
         violations
     }
 
-    fn extract_registered_icon(
-        line: &str,
-        registered_icons: &mut std::collections::HashSet<String>,
-    ) {
+    fn extract_registered_icon(line: &str, registered_icons: &mut HashSet<String>) {
         let Some(pos) = line.find("=>") else {
             return;
         };
@@ -81,30 +173,16 @@ impl IconsSyncOps {
         registered_icons.insert(icon_path.to_string());
     }
 
-    fn check_macro_registration(
-        line: &str,
-        i: usize,
-        types_rs_path: &Path,
-        actual_icons: &std::collections::HashSet<String>,
-        violations: &mut Vec<Violation>,
-    ) {
-        let Some(pos) = line.find("=>") else {
-            return;
-        };
-        let Some(start) = line[pos..].find('"') else {
-            return;
-        };
-        let Some(end) = line[pos + start + 1..].find('"') else {
-            return;
-        };
-        let icon_path = &line[pos + start + 1..pos + start + 1 + end];
-        if !actual_icons.contains(icon_path) {
-            violations.push(Violation {
-                file: types_rs_path.to_path_buf(),
-                line: i + 1,
-                column: pos + start,
-                message: format!("Icon registered in macro but SVG file does not exist in assets/icons/katana: {}.svg", icon_path),
-            });
-        }
+    #[rustfmt::skip]
+    fn get_duplicate_whitelist() -> &'static [&'static str] {
+        /* WHY: Whitelist by relative path substring or exact path */
+        &[
+            "navigation/chevron_down.svg", "navigation/chevron_left.svg", "navigation/chevron_right.svg",
+            "navigation/triangle_down.svg", "navigation/triangle_left.svg", "navigation/triangle_right.svg",
+            "view/pan_down.svg", "view/pan_right.svg", "ui/expand_all.svg", "ui/collapse_all.svg",
+            "ui/close.svg", "ui/remove.svg", "ui/copy.svg", "system/history.svg", "system/hourglass.svg",
+            "system/recent.svg", "system/github.svg", "layout/swap_horizontal.svg",
+            "layout/swap_vertical.svg", "files/explorer.svg",
+        ]
     }
 }

--- a/crates/katana-linter/src/rules/domains/assets/svg.rs
+++ b/crates/katana-linter/src/rules/domains/assets/svg.rs
@@ -25,8 +25,8 @@ fn check_line_for_invalid_colors(
                     line: line_num,
                     column: start_idx,
                     message: format!(
-                        "Invalid SVG color detected: `{}`. All icons must use `#FFFFFF` (or `none`) to support dynamic tinting.",
-                        color_val
+                        "Invalid SVG color detected: `{}` in attribute `{}`. All icons must use `#FFFFFF` (or `none`) to support dynamic tinting.",
+                        color_val, attr
                     ),
                 });
             }
@@ -85,8 +85,20 @@ impl SvgOps {
                 Err(_) => continue,
             };
 
-            /* WHY: For TintedMonochrome packs, we ensure all icons use `#FFFFFFF` or `currentColor`
+            /* WHY: For TintedMonochrome packs, we ensure all icons use `#FFFFFF` or `currentColor`
             This supports egui's dynamic tinting without destroying the icon's intended shapes. */
+
+            let has_fill = content.contains("fill=\"");
+            let has_stroke = content.contains("stroke=\"");
+
+            if !has_fill && !has_stroke {
+                violations.push(Violation {
+                    file: path.clone(),
+                    line: 1,
+                    column: 0,
+                    message: "Blackout Bug Detected: SVG has neither `fill` nor `stroke`. It will render as black and fail dynamic tinting. Add `fill=\"#FFFFFF\"` or `stroke=\"#FFFFFF\"`.".to_string(),
+                });
+            }
 
             let lines: Vec<&str> = content.lines().collect();
             for (i, line) in lines.iter().enumerate() {

--- a/crates/katana-linter/tests/ast_linter.rs
+++ b/crates/katana-linter/tests/ast_linter.rs
@@ -30,7 +30,19 @@ fn ast_linter_icon_sync() {
         IconsSyncOps::lint(LinterFileOps::workspace_root().expect("Test requirement"));
     ViolationReporterOps::panic(
         "icon-sync",
-        "Fix: Synchronize SVG files in assets/icons/katana/ with define_icons! macro in crates/katana-ui/src/icon/types.rs by ensuring 1-to-1 matching.",
+        "Fix: Synchronize SVG files in assets/icons/ with define_icons! macro by ensuring 1-to-1 matching across all themes.",
+        &all_violations,
+    );
+}
+
+#[test]
+fn ast_linter_svg_colors() {
+    use katana_linter::rules::domains::assets::SvgOps;
+    let all_violations =
+        SvgOps::lint_svg_colors(&LinterFileOps::workspace_root().expect("Test requirement"));
+    ViolationReporterOps::panic(
+        "svg-colors",
+        "Fix: SVGs must not have invalid colors (only #FFFFFF or currentColor allowed) and must have at least one fill or stroke attribute to prevent blackout.",
         &all_violations,
     );
 }

--- a/crates/katana-ui/src/state/mod.rs
+++ b/crates/katana-ui/src/state/mod.rs
@@ -33,7 +33,12 @@ pub mod app_state_tests {
         assert_eq!(SettingsTab::Workspace.section(), SettingsSection::Behavior);
         assert_eq!(
             SettingsSection::Appearance.tabs(),
-            &[SettingsTab::Theme, SettingsTab::Icons, SettingsTab::Font, SettingsTab::Layout]
+            &[
+                SettingsTab::Theme,
+                SettingsTab::Icons,
+                SettingsTab::Font,
+                SettingsTab::Layout
+            ]
         );
     }
 

--- a/crates/katana-ui/src/views/panels/explorer/file_entry.rs
+++ b/crates/katana-ui/src/views/panels/explorer/file_entry.rs
@@ -83,9 +83,10 @@ impl<'a, 'b, 'c> FileEntryNode<'a, 'b, 'c> {
                         .tint(text_color),
                 );
             } else {
-                child_ui.allocate_response(
-                    egui::vec2(crate::icon::IconSize::Medium.to_vec2().x, 0.0),
-                    egui::Sense::hover(),
+                child_ui.add(
+                    crate::icon::Icon::Document
+                        .image(crate::icon::IconSize::Medium)
+                        .tint(text_color),
                 );
             };
 

--- a/crates/katana-ui/src/views/panels/explorer/file_entry.rs
+++ b/crates/katana-ui/src/views/panels/explorer/file_entry.rs
@@ -78,7 +78,7 @@ impl<'a, 'b, 'c> FileEntryNode<'a, 'b, 'c> {
 
             if entry.is_markdown() {
                 child_ui.add(
-                    crate::icon::Icon::Document
+                    crate::icon::Icon::Markdown
                         .image(crate::icon::IconSize::Medium)
                         .tint(text_color),
                 );

--- a/openspec/changes/v0-17-0-icon-theme-packs/tasks.md
+++ b/openspec/changes/v0-17-0-icon-theme-packs/tasks.md
@@ -102,19 +102,19 @@ Tasks Grouped by ## = 各実装セッション中は、`/openspec-branching` ワ
 
 #### Sub Tasks
 
-- [ ] 5.1 `assets/icons/katana/` 配下などのSVGファイル一覧を取得する
-- [ ] 5.2 `crates/katana-ui/src/icon/types.rs` の `define_icons!` マクロなどに定義されている登録済みのアイコン一覧を抽出する
-- [ ] 5.3 ディレクトリ内に存在するが、コード（enum/ALL_ICONS等）に未登録のSVGファイルがある場合に追加漏れとしてエラーを報告するカスタムリンタールールを `katana-linter` に実装する
-- [ ] 5.4 登録されているがSVGファイルが存在しない場合も検出する
-- [ ] 5.5 SVGのアイコンがwhite listに登録されていないものは同一であることを許容しないast lintの設定を追加する。エラーメッセージに作成したskill (`.gemini/antigravity/skills/svg-icon-management/SKILL.md`) を参照することを出力する
-- [ ] 5.6 既存のSVGカラーチェック(`svg.rs`)を強化し、すべてのテーマパックの基本配色を `white` (`#FFFFFF`) または `currentColor` に完全に統一する。それ以外の固定色の使用を禁止し、かつ「`fill` も `stroke` も設定されていない（黒潰れする）」不備も検知してエラーにする
+- [x] 5.1 `assets/icons/katana/` 配下などのSVGファイル一覧を取得する
+- [x] 5.2 `crates/katana-ui/src/icon/types.rs` の `define_icons!` マクロなどに定義されている登録済みのアイコン一覧を抽出する
+- [x] 5.3 ディレクトリ内に存在するが、コード（enum/ALL_ICONS等）に未登録のSVGファイルがある場合に追加漏れとしてエラーを報告するカスタムリンタールールを `katana-linter` に実装する
+- [x] 5.4 登録されているがSVGファイルが存在しない場合も検出する
+- [x] 5.5 SVGのアイコンがwhite listに登録されていないものは同一であることを許容しないast lintの設定を追加する。エラーメッセージに作成したskill (`.gemini/antigravity/skills/svg-icon-management/SKILL.md`) を参照することを出力する
+- [x] 5.6 既存のSVGカラーチェック(`svg.rs`)を強化し、すべてのテーマパックの基本配色を `white` (`#FFFFFF`) または `currentColor` に完全に統一する。それ以外の固定色の使用を禁止し、かつ「`fill` も `stroke` も設定されていない（黒潰れする）」不備も検知してエラーにする
 
 ### Definition of Done (DoD)
 
-- [ ] `katana-linter` のカスタムルールにより、SVGの追加と登録の同期が検証可能になっていること
-- [ ] 意図的に未登録SVGを配置した場合にlinterが期待通り失敗することを確認すること
-- [ ] `make check` がエラーなし (exit code 0) で通過すること
-- [ ] `/openspec-delivery` ワークフローを実行し、デリバリールーチンを完了すること。
+- [x] `katana-linter` のカスタムルールにより、SVGの追加と登録の同期が検証可能になっていること
+- [x] 意図的に未登録SVGを配置した場合にlinterが期待通り失敗することを確認すること
+- [x] `make check` がエラーなし (exit code 0) で通過すること
+- [x] `/openspec-delivery` ワークフローを実行し、デリバリールーチンを完了すること。
 
 ---
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)
AST Linterを用いてSVGに課される独自のルールを堅牢に検証するための実装を行いました。またUI上のいくつかのアイコン表示崩れ（Bugアイコン、拡張子なしファイル）を修正しました。

## 対応内容 (Changes Made)
- `assets/icons/` 以下におけるSVGファイルと登録済みの列挙定義 (`define_icons!`) の相互同期状況・欠損をチェックするLinterを実装しました。
- 登録SVGについて、不正な色 (`#FFFFFF` または `currentColor` 以外) や、黒潰れするSVGの登録を明示的に禁止しました。
- Explorerにおいて、拡張子のないファイルの場合に `Icon::Document` をフォールバック表示するように修正しました。
- FeatherのbugアイコンにAlert-Octagonが代入されていたためLucideのもので修正しました。
- Linterにおけるルールチェック (ファイル長、ネスト制限、エラー優先など) への対応漏れを修正しました。

## 影響範囲 (Impact Scope)
- `katana-linter` (`assets` チェック機能)
- Explorer でのアイコン表示機構
- アイコンの `assets`