### PR TITLE
feat: ベンダーごとのプレビュー色付けとアイコンパックヘッダーの削除

### DIFF
--- a/crates/katana-ui/src/settings/tabs/icons.rs
+++ b/crates/katana-ui/src/settings/tabs/icons.rs
@@ -3,8 +3,6 @@ use crate::settings::*;
 
 impl IconsTabOps {
     pub(crate) fn render_icons_tab(ui: &mut egui::Ui, state: &mut crate::app_state::AppState) {
-        SettingsOps::section_header(ui, &crate::i18n::I18nOps::get().settings.theme.icon_pack);
-
         let mut current_pack = state.config.settings.settings().theme.icon_pack.clone();
 
         let available_packs = [
@@ -49,14 +47,38 @@ impl IconsTabOps {
             .id_salt("icon_pack_preview_scroll")
             .auto_shrink(false)
             .show(ui, |ui| {
-                ui.horizontal_wrapped(|ui| {
-                    const ITEM_SPACING: f32 = 16.0;
-                    ui.spacing_mut().item_spacing = egui::vec2(ITEM_SPACING, ITEM_SPACING);
-                    for icon in crate::icon::ALL_ICONS {
-                        let response = ui.add(icon.ui_image(ui, crate::icon::IconSize::Large));
-                        response.on_hover_text(icon.name());
-                    }
-                });
+                let mut grouped_icons: std::collections::BTreeMap<String, Vec<&crate::icon::Icon>> =
+                    std::collections::BTreeMap::new();
+
+                for icon in crate::icon::ALL_ICONS {
+                    let name = icon.name();
+                    let vendor = if let Some(slash_idx) = name.find('/') {
+                        name[..slash_idx].to_string()
+                    } else {
+                        "katana".to_string()
+                    };
+                    grouped_icons.entry(vendor).or_default().push(icon);
+                }
+
+                for (vendor, icons) in grouped_icons {
+                    egui::CollapsingHeader::new(&vendor)
+                        .default_open(true)
+                        .show(ui, |ui| {
+                            ui.horizontal_wrapped(|ui| {
+                                const ITEM_SPACING: f32 = 16.0;
+                                ui.spacing_mut().item_spacing =
+                                    egui::vec2(ITEM_SPACING, ITEM_SPACING);
+                                for icon in icons {
+                                    let image = icon.image(crate::icon::IconSize::Large);
+                                    let color = icon
+                                        .vendor_default_color(ui.visuals().dark_mode)
+                                        .unwrap_or(ui.visuals().text_color());
+                                    let response = ui.add(image.tint(color));
+                                    response.on_hover_text(icon.name());
+                                }
+                            });
+                        });
+                }
             });
     }
 }

--- a/openspec/changes/v0-17-2-icon-settings-expansion/tasks.md
+++ b/openspec/changes/v0-17-2-icon-settings-expansion/tasks.md
@@ -15,19 +15,19 @@ Tasks Grouped by ## = Adhere unconditionally to the branching standard defined i
 ### Definition of Done (DoD)
 
 - [x] `katana-core` 側のコンパイルと単体テストが通ること。
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+- [x] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ## 2. Vendor-based Default Icon Coloring & Preview UI
 
 ### Definition of Ready (DoR)
 
-- [ ] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
-- [ ] Base branch is synced, and a new branch is explicitly created for this task.
+- [x] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
+- [x] Base branch is synced, and a new branch is explicitly created for this task.
 
-- [ ] 2.1 `crates/katana-ui/src/views/settings.rs` のアイコン設定画面にて、`IconRegistry::iter()` から取得したアイコンをベンダー(プレフィックス)ごとにグループ化して `egui::CollapsingHeader` に格納する。
-- [ ] 2.2 グループ化された各ベンダーのアイコンプレビューに対して、`Icon::draw` に渡す色設定をベンダー別のデフォルト色で反映させる。
-- [ ] 2.3 ユーザーへのUIスナップショット（画像等）の提示および動作報告
-- [ ] 2.4 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+- [x] 2.1 `crates/katana-ui/src/views/settings.rs` のアイコン設定画面にて、`IconRegistry::iter()` から取得したアイコンをベンダー(プレフィックス)ごとにグループ化して `egui::CollapsingHeader` に格納する。
+- [x] 2.2 グループ化された各ベンダーのアイコンプレビューに対して、`Icon::draw` に渡す色設定をベンダー別のデフォルト色で反映させる。
+- [x] 2.3 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [x] 2.4 ユーザーからのフィードバックに基づくUIの微調整および改善実装
 
 ### Definition of Done (DoD)
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)
Task 2: UI implementation and tweaks for icon vendor grouping.

## 対応内容 (Changes Made)
- `ALL_ICONS` をベンダー（プレフィックス）単位でグループ化し、`egui::CollapsingHeader`で表示するよう変更（Task 2.1）
- 各アイコン描画時に `Icon::image().tint()` を呼び出し `vendor_default_color` でのプレビュー表示を適用（Task 2.2）
- ユーザーフィードバックに基づく「アイコンパック」ヘッダーの削除（Task 2.4）
- タスク管理上の完了記録（Task 2.3, 2.4）

## 影響範囲 (Impact Scope)
- `crates/katana-ui/src/settings/tabs/icons.rs`
- `openspec/changes/v0-17-2-icon-settings-expansion/tasks.md`

## 動作確認結果 (Verification Results)
- `make check` による静的解析およびテストにすべて合格