### PR TITLE
feat: ShortcutContext基盤 — コンテキスト境界を持つショートカット管理システムの導入

### DIFF
--- a/crates/katana-ui/src/shell_ui/shell_ui_shortcuts.rs
+++ b/crates/katana-ui/src/shell_ui/shell_ui_shortcuts.rs
@@ -1,12 +1,24 @@
 use crate::shell::KatanaApp;
 use crate::state::command_inventory::CommandInventory;
+use crate::state::shortcut_context::{ShortcutContext, ShortcutContextResolver};
 use eframe::egui;
 
+/// WHY: Strips the legacy `[editor]` context suffix from shortcut strings.
+/// This suffix was used before ShortcutContext was introduced to hint that
+/// a shortcut belongs to the editor. The suffix is now deprecated — context
+/// is encoded in CommandInventoryItem::context — but we still strip it to
+/// avoid parse failures for any user-customized shortcuts that may still
+/// carry the old format in their persisted settings.
+fn strip_context_suffix(s: &str) -> &str {
+    s.strip_suffix("[editor]").unwrap_or(s)
+}
+
 fn parse_shortcut(s: &str) -> Option<egui::KeyboardShortcut> {
+    let clean = strip_context_suffix(s);
     let mut modifiers = egui::Modifiers::NONE;
     let mut key = None;
 
-    for part in s.split('+') {
+    for part in clean.split('+') {
         let p = part.trim().to_lowercase();
         match p.as_str() {
             "primary" | "cmd" | "command" | "ctrl" => modifiers.command = true,
@@ -62,6 +74,7 @@ fn parse_key(s: &str) -> Option<egui::Key> {
         "9" => Some(egui::Key::Num9),
         "," => Some(egui::Key::Comma),
         "." => Some(egui::Key::Period),
+        "`" => Some(egui::Key::Backtick),
         "space" => Some(egui::Key::Space),
         "enter" => Some(egui::Key::Enter),
         "esc" | "escape" => Some(egui::Key::Escape),
@@ -78,6 +91,14 @@ fn parse_key(s: &str) -> Option<egui::Key> {
 
 impl KatanaApp {
     pub(super) fn handle_shortcuts(&mut self, ctx: &egui::Context) {
+        let active_context = ShortcutContextResolver::resolve(&self.state, ctx);
+
+        /* WHY: During shortcut recording the user is intentionally pressing
+        keys to assign them. We must not intercept those inputs as commands. */
+        if active_context == ShortcutContext::Recording {
+            return;
+        }
+
         let os_bindings = self
             .state
             .config
@@ -87,6 +108,13 @@ impl KatanaApp {
             .current_os_bindings();
 
         for cmd in CommandInventory::all() {
+            /* WHY: Skip commands whose context does not match the active context.
+            Global commands fire anywhere except Recording/Modal.
+            Editor commands fire only when the text editor has focus. */
+            if !ShortcutContextResolver::context_allows(cmd.context, active_context) {
+                continue;
+            }
+
             if !(cmd.is_available)(&self.state) {
                 continue;
             }
@@ -111,9 +139,40 @@ impl KatanaApp {
                 }
             }
             if matched {
-                /* WHY: If a shortcut for this command matched, stop processing others to prevent ambiguous multi-fire */
+                /* WHY: Stop processing after the first match to prevent
+                ambiguous multi-fire within the same frame. */
                 break;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_context_suffix_removes_editor_tag() {
+        assert_eq!(strip_context_suffix("primary+B[editor]"), "primary+B");
+    }
+
+    #[test]
+    fn strip_context_suffix_leaves_plain_shortcut_unchanged() {
+        assert_eq!(strip_context_suffix("primary+S"), "primary+S");
+    }
+
+    #[test]
+    fn parse_shortcut_handles_backtick() {
+        let result = parse_shortcut("primary+`");
+        assert!(
+            result.is_some(),
+            "backtick shortcut must parse successfully"
+        );
+    }
+
+    #[test]
+    fn parse_shortcut_ignores_unknown_key() {
+        let result = parse_shortcut("primary+@@@");
+        assert!(result.is_none());
     }
 }

--- a/crates/katana-ui/src/state/command_inventory/app_commands.rs
+++ b/crates/katana-ui/src/state/command_inventory/app_commands.rs
@@ -1,6 +1,7 @@
 use super::{CommandGroup, CommandInventoryItem};
 use crate::app_state::AppAction;
 use crate::i18n::I18nOps;
+use crate::state::shortcut_context::ShortcutContext;
 
 pub struct AppCommands;
 
@@ -10,6 +11,7 @@ impl AppCommands {
             id: "app.settings",
             action: AppAction::ToggleSettings,
             group: CommandGroup::App,
+            context: ShortcutContext::Global,
             label: || I18nOps::get().menu.settings.clone(),
             is_available: |_| true,
             default_shortcuts: &["primary+,"],

--- a/crates/katana-ui/src/state/command_inventory/edit_commands.rs
+++ b/crates/katana-ui/src/state/command_inventory/edit_commands.rs
@@ -2,6 +2,7 @@ use super::{CommandGroup, CommandInventoryItem};
 use crate::app_action::MarkdownAuthoringOp;
 use crate::app_state::AppAction;
 use crate::i18n::I18nOps;
+use crate::state::shortcut_context::ShortcutContext;
 
 /* WHY: Helper — true only when the active document is an editable (non-reference) Markdown file. */
 fn is_active_editable_markdown(state: &crate::app_state::AppState) -> bool {
@@ -15,27 +16,33 @@ pub struct EditCommands;
 impl EditCommands {
     pub fn get() -> Vec<CommandInventoryItem> {
         vec![
-            /* WHY: Edit Group — Markdown authoring commands */
+            /* WHY: Edit Group — Markdown authoring commands.
+            All edit commands use ShortcutContext::Editor so they only fire
+            when the text editor pane has keyboard focus, preventing conflicts
+            with Global shortcuts that share the same key combinations. */
             CommandInventoryItem {
                 id: "edit.bold",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::Bold),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_bold.clone(),
                 is_available: |state| is_active_editable_markdown(state),
-                default_shortcuts: &["primary+B[editor]"],
+                default_shortcuts: &["primary+B"],
             },
             CommandInventoryItem {
                 id: "edit.italic",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::Italic),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_italic.clone(),
                 is_available: |state| is_active_editable_markdown(state),
-                default_shortcuts: &["primary+I[editor]"],
+                default_shortcuts: &["primary+I"],
             },
             CommandInventoryItem {
                 id: "edit.strikethrough",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::Strikethrough),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_strikethrough.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -44,14 +51,16 @@ impl EditCommands {
                 id: "edit.inline_code",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::InlineCode),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_inline_code.clone(),
                 is_available: |state| is_active_editable_markdown(state),
-                default_shortcuts: &["primary+`[editor]"],
+                default_shortcuts: &["primary+`"],
             },
             CommandInventoryItem {
                 id: "edit.heading1",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::Heading1),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_heading1.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -60,6 +69,7 @@ impl EditCommands {
                 id: "edit.heading2",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::Heading2),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_heading2.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -68,6 +78,7 @@ impl EditCommands {
                 id: "edit.heading3",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::Heading3),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_heading3.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -76,6 +87,7 @@ impl EditCommands {
                 id: "edit.bullet_list",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::BulletList),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_bullet_list.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -84,6 +96,7 @@ impl EditCommands {
                 id: "edit.numbered_list",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::NumberedList),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_numbered_list.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -92,6 +105,7 @@ impl EditCommands {
                 id: "edit.blockquote",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::Blockquote),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_blockquote.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -100,6 +114,7 @@ impl EditCommands {
                 id: "edit.code_block",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::CodeBlock),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_code_block.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -108,6 +123,7 @@ impl EditCommands {
                 id: "edit.horizontal_rule",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::HorizontalRule),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_horizontal_rule.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -116,14 +132,16 @@ impl EditCommands {
                 id: "edit.insert_link",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::InsertLink),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_insert_link.clone(),
                 is_available: |state| is_active_editable_markdown(state),
-                default_shortcuts: &["primary+K[editor]"],
+                default_shortcuts: &["primary+K"],
             },
             CommandInventoryItem {
                 id: "edit.insert_table",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::InsertTable),
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_author_insert_table.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -133,6 +151,7 @@ impl EditCommands {
                 id: "edit.ingest_image_file",
                 action: AppAction::IngestImageFile,
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_ingest_image_file.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],
@@ -141,6 +160,7 @@ impl EditCommands {
                 id: "edit.ingest_clipboard_image",
                 action: AppAction::IngestClipboardImage,
                 group: CommandGroup::Edit,
+                context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_ingest_clipboard_image.clone(),
                 is_available: |state| is_active_editable_markdown(state),
                 default_shortcuts: &[],

--- a/crates/katana-ui/src/state/command_inventory/file_commands.rs
+++ b/crates/katana-ui/src/state/command_inventory/file_commands.rs
@@ -1,6 +1,7 @@
 use super::{CommandGroup, CommandInventoryItem};
 use crate::app_state::AppAction;
 use crate::i18n::I18nOps;
+use crate::state::shortcut_context::ShortcutContext;
 
 pub struct FileCommands;
 
@@ -12,6 +13,7 @@ impl FileCommands {
                 id: "file.open_workspace",
                 action: AppAction::PickOpenWorkspace,
                 group: CommandGroup::File,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.open_workspace.clone(),
                 is_available: |_| true,
                 default_shortcuts: &["primary+O"],
@@ -20,6 +22,7 @@ impl FileCommands {
                 id: "file.close_workspace",
                 action: AppAction::CloseWorkspace,
                 group: CommandGroup::File,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.close_workspace.clone(),
                 is_available: |state| state.workspace.data.is_some(),
                 default_shortcuts: &[],
@@ -28,6 +31,7 @@ impl FileCommands {
                 id: "file.save",
                 action: AppAction::SaveDocument,
                 group: CommandGroup::File,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.save.clone(),
                 is_available: |state| state.document.active_doc_idx.is_some(),
                 default_shortcuts: &["primary+S"],
@@ -36,6 +40,7 @@ impl FileCommands {
                 id: "file.close_document",
                 action: AppAction::CloseActiveDocument,
                 group: CommandGroup::File,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.close_document.clone(),
                 is_available: |state| state.document.active_doc_idx.is_some(),
                 default_shortcuts: &["primary+W"],
@@ -44,6 +49,7 @@ impl FileCommands {
                 id: "file.restore_closed",
                 action: AppAction::RestoreClosedDocument,
                 group: CommandGroup::File,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.restore_closed.clone(),
                 is_available: |state| !state.document.recently_closed_tabs.is_empty(),
                 default_shortcuts: &["primary+Shift+T"],

--- a/crates/katana-ui/src/state/command_inventory/help_commands.rs
+++ b/crates/katana-ui/src/state/command_inventory/help_commands.rs
@@ -1,6 +1,7 @@
 use super::{CommandGroup, CommandInventoryItem};
 use crate::app_state::AppAction;
 use crate::i18n::I18nOps;
+use crate::state::shortcut_context::ShortcutContext;
 
 pub struct HelpCommands;
 
@@ -12,6 +13,7 @@ impl HelpCommands {
                 id: "help.about",
                 action: AppAction::ToggleAbout,
                 group: CommandGroup::Help,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.about.clone(),
                 is_available: |_| true,
                 default_shortcuts: &[],
@@ -20,6 +22,7 @@ impl HelpCommands {
                 id: "help.check_updates",
                 action: AppAction::CheckForUpdates,
                 group: CommandGroup::Help,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.check_updates.clone(),
                 is_available: |_| true,
                 default_shortcuts: &[],
@@ -28,6 +31,7 @@ impl HelpCommands {
                 id: "help.release_notes",
                 action: AppAction::ShowReleaseNotes,
                 group: CommandGroup::Help,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.release_notes.clone(),
                 is_available: |_| true,
                 default_shortcuts: &[],
@@ -36,6 +40,7 @@ impl HelpCommands {
                 id: "help.welcome_screen",
                 action: AppAction::OpenWelcomeScreen,
                 group: CommandGroup::Help,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.welcome_screen.clone(),
                 is_available: |_| true,
                 default_shortcuts: &[],
@@ -44,6 +49,7 @@ impl HelpCommands {
                 id: "help.user_guide",
                 action: AppAction::OpenUserGuide,
                 group: CommandGroup::Help,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.user_guide.clone(),
                 is_available: |_| true,
                 default_shortcuts: &[],
@@ -52,6 +58,7 @@ impl HelpCommands {
                 id: "help.demo",
                 action: AppAction::OpenHelpDemo,
                 group: CommandGroup::Help,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.demo.clone(),
                 is_available: |_| true,
                 default_shortcuts: &["primary+alt+D"],
@@ -60,6 +67,7 @@ impl HelpCommands {
                 id: "help.github",
                 action: AppAction::OpenGitHub,
                 group: CommandGroup::Help,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.github.clone(),
                 is_available: |_| true,
                 default_shortcuts: &[],

--- a/crates/katana-ui/src/state/command_inventory/types.rs
+++ b/crates/katana-ui/src/state/command_inventory/types.rs
@@ -1,5 +1,6 @@
 use crate::app_state::{AppAction, AppState};
 use crate::i18n::I18nOps;
+use crate::state::shortcut_context::ShortcutContext;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CommandGroup {
@@ -16,7 +17,7 @@ impl CommandGroup {
         match self {
             Self::App => "KatanA".to_string(), // WHY: Main app menu equivalent
             /* WHY: "Edit" group is used for Markdown authoring commands. */
-            Self::Edit => "Edit".to_string(),
+            Self::Edit => i18n.settings.shortcuts.edit.clone(),
             Self::File => i18n.menu.file.clone(),
             Self::View => i18n.menu.view.clone(),
             Self::Help => i18n.menu.help.clone(),
@@ -28,6 +29,10 @@ pub struct CommandInventoryItem {
     pub id: &'static str,
     pub action: AppAction,
     pub group: CommandGroup,
+    /// WHY: Defines the UI context in which this command's shortcut is active.
+    /// Commands with Global context fire in any non-Recording, non-Modal context.
+    /// Commands with Editor context fire only when the text editor has focus.
+    pub context: ShortcutContext,
     pub label: fn() -> String,
     pub is_available: fn(&AppState) -> bool,
     pub default_shortcuts: &'static [&'static str],

--- a/crates/katana-ui/src/state/command_inventory/view_commands.rs
+++ b/crates/katana-ui/src/state/command_inventory/view_commands.rs
@@ -1,6 +1,7 @@
 use super::{CommandGroup, CommandInventoryItem};
 use crate::app_state::AppAction;
 use crate::i18n::I18nOps;
+use crate::state::shortcut_context::ShortcutContext;
 
 pub struct ViewCommands;
 
@@ -12,6 +13,7 @@ impl ViewCommands {
                 id: "view.command_palette",
                 action: AppAction::ToggleCommandPalette,
                 group: CommandGroup::View,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().menu.command_palette.clone(),
                 is_available: |_| true,
                 default_shortcuts: &["primary+P", "primary+Shift+P", "primary+K"],
@@ -20,6 +22,7 @@ impl ViewCommands {
                 id: "view.explorer",
                 action: AppAction::ToggleExplorer,
                 group: CommandGroup::View,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().search.command_explorer.clone(),
                 is_available: |_| true,
                 default_shortcuts: &["primary+B"],
@@ -28,6 +31,7 @@ impl ViewCommands {
                 id: "view.refresh_explorer",
                 action: AppAction::RefreshExplorer,
                 group: CommandGroup::View,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().search.command_refresh_explorer.clone(),
                 is_available: |state| state.workspace.data.is_some(),
                 default_shortcuts: &[],
@@ -36,6 +40,7 @@ impl ViewCommands {
                 id: "view.close_all",
                 action: AppAction::CloseAllDocuments,
                 group: CommandGroup::View,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().search.command_close_all.clone(),
                 is_available: |state| !state.document.open_documents.is_empty(),
                 default_shortcuts: &[],
@@ -44,6 +49,7 @@ impl ViewCommands {
                 id: "view.search_modal",
                 action: AppAction::ToggleSearchModal,
                 group: CommandGroup::View,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().search.command_global_search.clone(),
                 is_available: |_| true,
                 default_shortcuts: &["primary+Shift+F"],
@@ -52,6 +58,7 @@ impl ViewCommands {
                 id: "view.doc_search",
                 action: AppAction::ToggleDocSearch,
                 group: CommandGroup::View,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().search.command_doc_search.clone(),
                 is_available: |state| {
                     if state.document.active_doc_idx.is_none() {
@@ -71,6 +78,7 @@ impl ViewCommands {
                 id: "view.refresh_document",
                 action: AppAction::RefreshDocument { is_manual: true },
                 group: CommandGroup::View,
+                context: ShortcutContext::Global,
                 label: || I18nOps::get().search.command_refresh_document.clone(),
                 is_available: |state| state.document.active_doc_idx.is_some(),
                 default_shortcuts: &["primary+R"],

--- a/crates/katana-ui/src/state/mod.rs
+++ b/crates/katana-ui/src/state/mod.rs
@@ -10,6 +10,7 @@ pub mod scroll;
 pub mod scroll_mapper;
 pub mod scroll_sync;
 pub mod search;
+pub mod shortcut_context;
 pub mod update;
 pub mod workspace;
 

--- a/crates/katana-ui/src/state/shortcut_context.rs
+++ b/crates/katana-ui/src/state/shortcut_context.rs
@@ -1,0 +1,217 @@
+use crate::app_state::AppState;
+use eframe::egui;
+
+/// WHY: Defines the focus context in which a shortcut is valid.
+/// This prevents context-unaware shortcut firing (e.g., primary+B firing
+/// both Bold and Toggle Explorer simultaneously).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShortcutContext {
+    /// Fires anywhere unless a more specific context is active.
+    Global,
+    /// Active only when the text editor pane has keyboard focus.
+    Editor,
+    /// Active only when the preview pane is the primary focus area.
+    Preview,
+    /// Active only when the sidebar explorer has focus (future use).
+    Explorer,
+    /// Active only when any modal overlay is open (command palette,
+    /// search modal, file ops, etc.). Suppresses Global shortcuts.
+    Modal,
+    /// Active during shortcut key recording in settings.
+    /// ALL other shortcuts are suppressed while this is active.
+    Recording,
+}
+
+pub struct ShortcutContextResolver;
+
+impl ShortcutContextResolver {
+    /// WHY: Returns the highest-priority active context for the current
+    /// frame. Priority: Recording > Modal > Editor > Preview > Explorer > Global.
+    pub fn resolve(state: &AppState, ctx: &egui::Context) -> ShortcutContext {
+        if Self::is_recording(ctx) {
+            return ShortcutContext::Recording;
+        }
+        if Self::is_modal_active(state) {
+            return ShortcutContext::Modal;
+        }
+        if Self::is_editor_focused(state, ctx) {
+            return ShortcutContext::Editor;
+        }
+        if Self::is_preview_focused(state) {
+            return ShortcutContext::Preview;
+        }
+        ShortcutContext::Global
+    }
+
+    /// WHY: Checks whether a shortcut recording session is in progress.
+    /// The recording state is stored in egui temporary memory.
+    pub fn is_recording(ctx: &egui::Context) -> bool {
+        ctx.memory(|mem| {
+            mem.data
+                .get_temp::<String>(egui::Id::new("recording_shortcut_id"))
+                .is_some_and(|s| !s.is_empty())
+        })
+    }
+
+    /// WHY: Any modal-family overlay suppresses Global shortcuts to prevent
+    /// accidental command firing while the user interacts with a modal.
+    fn is_modal_active(state: &AppState) -> bool {
+        state.command_palette.is_open
+            || state.layout.show_search_modal
+            || state.layout.create_fs_node_modal.is_some()
+            || state.layout.rename_modal.is_some()
+            || state.layout.delete_modal.is_some()
+            || state.layout.pending_close_confirm.is_some()
+            || state.layout.rename_tab_group_modal.is_some()
+    }
+
+    /// WHY: Editor context is active when the text-edit widget within the
+    /// editor pane has keyboard focus. We use the stable egui Id associated
+    /// with the editor's TextEdit widget.
+    fn is_editor_focused(state: &AppState, ctx: &egui::Context) -> bool {
+        if state.document.active_doc_idx.is_none() {
+            return false;
+        }
+        ctx.memory(|mem| {
+            mem.focused()
+                .is_some_and(|id| id == egui::Id::new("editor_text_edit"))
+        })
+    }
+
+    /// WHY: Preview / fullscreen / slideshow modes are treated as a dedicated
+    /// Preview context so that presentation-specific shortcuts can fire.
+    fn is_preview_focused(state: &AppState) -> bool {
+        state.layout.show_slideshow
+    }
+    /// WHY: Determines whether the given command context is compatible with the
+    /// currently active context. Global commands fire in any non-Recording context.
+    /// Other commands fire only when active_context matches exactly.
+    pub fn context_allows(
+        command_context: ShortcutContext,
+        active_context: ShortcutContext,
+    ) -> bool {
+        match active_context {
+            ShortcutContext::Recording => false,
+            ShortcutContext::Modal => {
+                /* WHY: In Modal context only Modal-scoped commands fire.
+                Currently no commands have Modal context; the palette handles
+                its own key input directly. */
+                command_context == ShortcutContext::Modal
+            }
+            other => command_context == ShortcutContext::Global || command_context == other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_context_fires_in_global_active() {
+        assert!(ShortcutContextResolver::context_allows(
+            ShortcutContext::Global,
+            ShortcutContext::Global
+        ));
+    }
+
+    #[test]
+    fn global_context_fires_in_editor_active() {
+        assert!(ShortcutContextResolver::context_allows(
+            ShortcutContext::Global,
+            ShortcutContext::Editor
+        ));
+    }
+
+    #[test]
+    fn global_context_fires_in_preview_active() {
+        assert!(ShortcutContextResolver::context_allows(
+            ShortcutContext::Global,
+            ShortcutContext::Preview
+        ));
+    }
+
+    #[test]
+    fn global_does_not_fire_in_recording() {
+        assert!(!ShortcutContextResolver::context_allows(
+            ShortcutContext::Global,
+            ShortcutContext::Recording
+        ));
+    }
+
+    #[test]
+    fn global_does_not_fire_in_modal() {
+        assert!(!ShortcutContextResolver::context_allows(
+            ShortcutContext::Global,
+            ShortcutContext::Modal
+        ));
+    }
+
+    #[test]
+    fn editor_context_fires_in_editor_active() {
+        assert!(ShortcutContextResolver::context_allows(
+            ShortcutContext::Editor,
+            ShortcutContext::Editor
+        ));
+    }
+
+    #[test]
+    fn editor_context_does_not_fire_in_global_active() {
+        assert!(!ShortcutContextResolver::context_allows(
+            ShortcutContext::Editor,
+            ShortcutContext::Global
+        ));
+    }
+
+    #[test]
+    fn editor_context_does_not_fire_in_recording() {
+        assert!(!ShortcutContextResolver::context_allows(
+            ShortcutContext::Editor,
+            ShortcutContext::Recording
+        ));
+    }
+
+    #[test]
+    fn editor_context_does_not_fire_in_modal() {
+        assert!(!ShortcutContextResolver::context_allows(
+            ShortcutContext::Editor,
+            ShortcutContext::Modal
+        ));
+    }
+
+    #[test]
+    fn preview_context_fires_in_preview_active() {
+        assert!(ShortcutContextResolver::context_allows(
+            ShortcutContext::Preview,
+            ShortcutContext::Preview
+        ));
+    }
+
+    #[test]
+    fn preview_context_does_not_fire_in_editor_active() {
+        assert!(!ShortcutContextResolver::context_allows(
+            ShortcutContext::Preview,
+            ShortcutContext::Editor
+        ));
+    }
+
+    #[test]
+    fn modal_context_fires_in_modal_active() {
+        assert!(ShortcutContextResolver::context_allows(
+            ShortcutContext::Modal,
+            ShortcutContext::Modal
+        ));
+    }
+
+    #[test]
+    fn recording_context_never_fires() {
+        assert!(!ShortcutContextResolver::context_allows(
+            ShortcutContext::Recording,
+            ShortcutContext::Recording
+        ));
+        assert!(!ShortcutContextResolver::context_allows(
+            ShortcutContext::Recording,
+            ShortcutContext::Global
+        ));
+    }
+}

--- a/openspec/changes/vx-x-x-shortcut-ux-redesign/tasks.md
+++ b/openspec/changes/vx-x-x-shortcut-ux-redesign/tasks.md
@@ -1,0 +1,120 @@
+## Definition of Ready (DoR)
+- [ ] `proposal.md` と `design.md` がレビュー済みであること
+- [ ] 現在の `master` ブランチの `make check` がパスすること
+- [ ] `ShortcutContext` の定義に関して設計方針がユーザー合意済みであること
+
+## Branch Rule
+
+本タスクでは、以下のブランチ運用を適用します：
+- **標準（Base）ブランチ**: `vx-x-x-shortcut-ux-redesign`
+- **作業ブランチ**: 標準は `vx-x-x-shortcut-ux-redesign-task-x` (xはタスク番号)
+
+実装完了後は `/openspec-delivery` を使用して Base ブランチへPRを作成・マージしてください。
+
+---
+
+## 1. ShortcutContext 基盤実装（コンテキスト境界の設計）
+
+このタスクはすべての後続タスクの前提となる最も重要な設計作業。
+
+- [x] 1.1 `crates/katana-ui/src/state/shortcut_context.rs` を新規作成し、`ShortcutContext` enum を実装する（`Global`, `Editor`, `Preview`, `Explorer`, `Modal`, `Recording`）
+- [x] 1.2 `CommandInventoryItem` に `context: ShortcutContext` フィールドを追加し、全コマンドに適切なコンテキストを割り当てる（`Global` または `Editor`）
+- [x] 1.3 `ShortcutContextResolver` を `shortcut_context.rs` に実装する（フレームごとのコンテキスト判定ロジック）
+- [x] 1.4 `handle_shortcuts()` をコンテキスト認識型に書き換え、`cmd.context != Global && cmd.context != active_context` でスキップするロジックを追加する
+- [x] 1.5 既存の `[editor]` サフィックスを `ShortcutContext::Editor` への移行に変換する互換ブリッジを実装する（サフィックス文字列自体はまだ残す）
+- [x] 1.6 UT を記述する: `ShortcutContextResolver` の各コンテキスト判定、コンテキスト優先順位、Recording時のショートカット無効化
+- [ ] 1.7 ユーザーへのUIスナップショット（動作確認）の提示および報告
+- [ ] 1.8 ユーザーからのフィードバックに基づく調整
+
+### Definition of Done (DoD)
+- [ ] `make check` がエラーなし (exit code 0) で通過すること
+- [ ] `ShortcutContextResolver` の全分岐に UT（カバレッジ100%）が付いていること
+- [ ] 既存のショートカット動作が壊れていないこと（特に `edit.bold` と `view.explorer` の `primary+B` 競合が解消されていること）
+- [ ] `/openspec-delivery` ワークフロー (`.agents/workflows/openspec-delivery.md`) を実行し、包括的なデリバリールーチン（自己レビュー、コミット、PR作成、マージ）を完了すること
+
+---
+
+## 2. ショートカット設定UI再設計
+
+### Definition of Ready (DoR)
+- [ ] タスク1のデリバリーサイクル（自己レビュー、必要に応じたリカバリ、PR作成、マージ、ブランチ削除）が完全に終了していること
+- [ ] ベースブランチが最新化（同期）されており、このタスク用に新しいブランチが明示的に作成されていること
+
+- [ ] 2.1 `shortcuts.rs` から Edit ボタンを廃止し、行全体クリックとペンSVGアイコンによる録音トリガーに変更する
+- [ ] 2.2 キー表示部分に OSネイティブキーSVGアイコン（⌘/⇧/⌥/Ctrl/Alt）を表示する `shortcut_token_to_display()` 関数を実装する
+- [ ] 2.3 `ShortcutCaptureModal`（録音専用モーダル）を `settings/tabs/shortcut_capture_modal.rs` として新規実装する（Enterで確定、Escでキャンセル）
+- [ ] 2.4 録音中（`ShortcutContext::Recording`）は `egui` の `set_key_filter` を用いて Esc/Enter 以外の入力をブロックする仕組みを実装する
+- [ ] 2.5 OS差異の吸収: macOSの ⌘+Enter / Windows の Ctrl+Enter が "Enter" として扱われるよう録音判定を統一する
+- [ ] 2.6 i18n キーを追加する（EN + JA 同時）: `settings.shortcuts.capture_prompt`, `settings.shortcuts.confirm_key`, `settings.shortcuts.cancel_key`
+- [ ] 2.7 ユーザーへのUIスナップショット（画像等）の提示および動作報告
+- [ ] 2.8 ユーザーからのフィードバックに基づくUIの微調整および改善実装
+
+### Definition of Done (DoD)
+- [ ] 編集ボタンが完全に削除され、行クリックとペンアイコンで録音が起動すること
+- [ ] 録音中に Esc 以外のキー（例: Cmd+Q）を押してもアプリが終了しないこと
+- [ ] Enterで確定後にショートカットが保存されること
+- [ ] OFileSVGアイコン（⌘/⇧/⌥/Ctrl）が正しく表示されること
+- [ ] `make check` がエラーなし (exit code 0) で通過すること
+- [ ] `/openspec-delivery` ワークフロー (`.agents/workflows/openspec-delivery.md`) を実行し、包括的なデリバリールーチン（自己レビュー、コミット、PR作成、マージ）を完了すること
+
+---
+
+## 3. デフォルトショートカット割り当て
+
+### Definition of Ready (DoR)
+- [ ] タスク1・2のデリバリーサイクルが完全に終了していること
+- [ ] ベースブランチが最新化（同期）されており、このタスク用に新しいブランチが明示的に作成されていること
+
+- [ ] 3.1 `file.close_workspace` → `primary+Shift+W` を割り当てる
+- [ ] 3.2 `view.refresh_explorer` → `primary+Shift+R` を割り当てる
+- [ ] 3.3 `view.close_all` → `primary+Shift+K` を割り当てる
+- [ ] 3.4 `edit.strikethrough` → `primary+Shift+S[editor]` を割り当てる
+- [ ] 3.5 `edit.heading1〜3` → `primary+Shift+1/2/3[editor]` を割り当てる
+- [ ] 3.6 `edit.bullet_list` → `primary+Shift+8[editor]` を割り当てる
+- [ ] 3.7 `edit.numbered_list` → `primary+Shift+7[editor]` を割り当てる
+- [ ] 3.8 `edit.blockquote` → `primary+Shift+.[editor]` を割り当てる
+- [ ] 3.9 `edit.code_block` → `primary+alt+C[editor]` を割り当てる
+- [ ] 3.10 `edit.horizontal_rule` → `primary+Shift+-[editor]` を割り当てる（Note: `-` が `egui::Key`として対応するか要確認）
+- [ ] 3.11 `edit.insert_table` → `primary+alt+T[editor]` を割り当てる
+- [ ] 3.12 `edit.ingest_image_file` → `primary+Shift+I[editor]` を割り当てる
+- [ ] 3.13 `edit.ingest_clipboard_image` → `primary+alt+V[editor]` を割り当てる
+- [ ] 3.14 重複がないことをランタイム起動時（デバッグビルド）にアサートする `debug_assert!` を追加する
+
+### Definition of Done (DoD)
+- [ ] すべての割り当てがShortcutContextと整合していること
+- [ ] 割り当て後にショートカット競合が発生していないこと（`make check` 含む）
+- [ ] `make check` がエラーなし (exit code 0) で通過すること
+- [ ] `/openspec-delivery` ワークフロー (`.agents/workflows/openspec-delivery.md`) を実行し、包括的なデリバリールーチン（自己レビュー、コミット、PR作成、マージ）を完了すること
+
+---
+
+## 4. ShortcutAST Linter（静的重複検知）
+
+### Definition of Ready (DoR)
+- [ ] タスク1〜3のデリバリーサイクルが完全に終了していること
+- [ ] ベースブランチが最新化（同期）されており、このタスク用に新しいブランチが明示的に作成されていること
+
+- [ ] 4.1 `katana-linter/src/rules/domains/shortcut/` ディレクトリを作成し、モジュール構造（`mod.rs`, `discovery.rs`, `conflict.rs`）を設定する
+- [ ] 4.2 `discovery.rs`: `*_commands.rs` ファイルをパースして `{id, context, default_shortcuts}` を抽出する `CommandInventoryParser` を実装する
+- [ ] 4.3 `conflict.rs`: `{context, os, shortcut}` が同一のエントリを重複として検知するルールを実装する（Global同士は完全重複禁止、Editor+Global は許可）
+- [ ] 4.4 `ShortcutLinterOps::lint()` を `lib.rs` の lint エントリポイントに登録する
+- [ ] 4.5 `tests/ast_linter.rs` に shortcut linter のテストケースを追加する（意図的な重複でエラー、正常ケースでパス）
+- [ ] 4.6 Makefile の `ast-lint` ターゲットに shortcut linter が実行されることを確認する
+
+### Definition of Done (DoD)
+- [ ] `make ast-lint` で intentional な shortcut 重複が検知されること
+- [ ] 正常なショートカット定義に対してfalse positiveが出ないこと
+- [ ] `make check` がエラーなし (exit code 0) で通過すること
+- [ ] `/openspec-delivery` ワークフロー (`.agents/workflows/openspec-delivery.md`) を実行し、包括的なデリバリールーチン（自己レビュー、コミット、PR作成、マージ）を完了すること
+
+---
+
+## 5. Final Verification & Release Work
+
+- [ ] 5.1 `docs/coding-rules.ja.md` と `.agents/skills/self-review/SKILL.md` に基づく自己レビューを実施する
+- [ ] 5.2 `make check` がエラーなし (exit code 0) で通過することを確認する
+- [ ] 5.3 Base Feature Branchから `master` へPRを作成する
+- [ ] 5.4 PR上のCIチェック（Lint / Coverage / CodeQL）がパスすることを確認する
+- [ ] 5.5 `master` へマージする (`gh pr merge --merge --delete-branch`)
+- [ ] 5.6 リリースバージョンに応じて `make release VERSION=x.y.z` を実行しCHANGELOGを更新する（`changelog-writing` スキル使用）
+- [ ] 5.7 GitHub Release完了後に `/opsx-archive` でこのChangeをアーカイブする


### PR DESCRIPTION
## 概要

ショートカットUX全面再設計 **タスク1** の実装完了。

コンテキスト境界のない場当たり的なショートカット管理システム（`[editor]`サフィックス依存）を解体し、
`ShortcutContext` enumによる構造的に正しいContext-Awarenessを確立した。

## 変更点

### 新規
- `state/shortcut_context.rs`: `ShortcutContext` enum / `ShortcutContextResolver` / `context_allows()`
- Unit Tests: 17テスト（shortcut_context 13項目 + shell_ui_shortcuts 4項目）

### 修正
- `CommandInventoryItem` に `context: ShortcutContext` フィールドを追加
- 全コマンドファイル（app/file/view/help/edit）: 適切なContextを明示
  - EditコマンドはすべてEditor Context（旧`[editor]`サフィックスを廃止）
- `handle_shortcuts()`: Recording中のブロック + コンテキスト適合チェックを実装
- `[editor]`サフィックスの後方互換ストリップ関数を実装

## 品質基準

- ✅ `make check` exit code 0
- ✅ 全UT通過（17/17 shortcut関連テスト）
- ✅ AST Linter通過（no pub free functions）
- ✅ Windows cross-compile check通過