### PR TITLE
ops: lefthookのpr-ready-checkをrelease/masterに限定

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,9 @@ pre-push:
   commands:
     pr-ready-check:
       run: ./scripts/release/check-pr-ready.sh
+      only:
+        - ref: master
+        - ref: release/*
     check-strict:
       run: make -j 2 check
       glob: "*.{rs,toml,lock}"


### PR DESCRIPTION
Featureブランチでの開発をアンブロックするための運用修正