### PR TITLE
fix: エクスプローラーフィルターの無限幅増殖バグ修正

### DIFF
--- a/crates/katana-ui/src/views/panels/explorer/header.rs
+++ b/crates/katana-ui/src/views/panels/explorer/header.rs
@@ -170,7 +170,7 @@ impl<'a> ExplorerHeader<'a> {
                         egui::TextEdit::singleline(&mut search.filter_query)
                             .text_color(text_color)
                             .hint_text(&crate::i18n::I18nOps::get().workspace.filter_regex_hint)
-                            .desired_width(f32::INFINITY),
+                            .desired_width(ui.available_width()),
                     );
                 })
                 .show(ui);


### PR DESCRIPTION
緊急対応: f32::INFINITYが親レイアウトを無限に拡張させてしまうeguiの制約抜けを修正