### PR TITLE
fix: エクスプローラーフィルターのUI拡張無限ループの完全修正(TDD準拠)

### DIFF
--- a/crates/katana-ui/src/views/panels/explorer/header.rs
+++ b/crates/katana-ui/src/views/panels/explorer/header.rs
@@ -148,32 +148,25 @@ impl<'a> ExplorerHeader<'a> {
                     .build()
                     .is_ok();
             }
-            crate::widgets::AlignCenter::new()
-                .shrink_to_fit(true)
-                .content(|ui| {
-                    let text_color = if is_valid_regex {
-                        ui.visuals().text_color()
-                    } else {
-                        ui.ctx()
-                            .data(|d| {
-                                d.get_temp::<katana_platform::theme::ThemeColors>(egui::Id::new(
-                                    "katana_theme_colors",
-                                ))
-                            })
-                            .map_or(crate::theme_bridge::WHITE, |tc| {
-                                crate::theme_bridge::ThemeBridgeOps::rgb_to_color32(
-                                    tc.system.error_text,
-                                )
-                            })
-                    };
-                    ui.add(
-                        egui::TextEdit::singleline(&mut search.filter_query)
-                            .text_color(text_color)
-                            .hint_text(&crate::i18n::I18nOps::get().workspace.filter_regex_hint)
-                            .desired_width(ui.available_width()),
-                    );
-                })
-                .show(ui);
+            let text_color = if is_valid_regex {
+                ui.visuals().text_color()
+            } else {
+                ui.ctx()
+                    .data(|d| {
+                        d.get_temp::<katana_platform::theme::ThemeColors>(egui::Id::new(
+                            "katana_theme_colors",
+                        ))
+                    })
+                    .map_or(crate::theme_bridge::WHITE, |tc| {
+                        crate::theme_bridge::ThemeBridgeOps::rgb_to_color32(tc.system.error_text)
+                    })
+            };
+            ui.add(
+                egui::TextEdit::singleline(&mut search.filter_query)
+                    .text_color(text_color)
+                    .hint_text(&crate::i18n::I18nOps::get().workspace.filter_regex_hint)
+                    .desired_width(ui.available_width()),
+            );
         }
     }
 }

--- a/crates/katana-ui/src/views/panels/explorer/header_tests.rs
+++ b/crates/katana-ui/src/views/panels/explorer/header_tests.rs
@@ -1,0 +1,74 @@
+#[cfg(test)]
+mod tests {
+    use crate::app_state::{AppAction, SearchState, WorkspaceState};
+    use crate::views::panels::explorer::header::ExplorerHeader;
+    use eframe::egui::{self, Rect, pos2};
+
+    fn test_context() -> egui::Context {
+        egui::Context::default()
+    }
+
+    fn test_input(size: egui::Vec2) -> egui::RawInput {
+        egui::RawInput {
+            screen_rect: Some(Rect::from_min_size(pos2(0.0, 0.0), size)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn explorer_filter_input_width_is_stable_and_does_not_expand_infinitely() {
+        let ctx = test_context();
+        let mut ws = WorkspaceState::default();
+        /* WHY: Just providing empty workspace representation is enough to trigger `ws.data.is_some()` */
+        ws.data = Some(katana_core::workspace::Workspace::new("/", vec![]));
+
+        let mut search = SearchState::default();
+        search.filter_enabled = true; /* WHY: Show filter input! */
+
+        let mut action = AppAction::None;
+
+        let mut panel_width_frame1 = 0.0;
+        let mut panel_width_frame2 = 0.0;
+        let mut panel_width_frame3 = 0.0;
+
+        let _ = ctx.run(test_input(egui::vec2(1200.0, 800.0)), |ctx| {
+            let resp = egui::SidePanel::left("explorer_test_panel")
+                .resizable(true)
+                .show(ctx, |ui| {
+                    ExplorerHeader::new(&mut ws, &mut search, &mut action).show(ui);
+                });
+            panel_width_frame1 = resp.response.rect.width();
+        });
+
+        let _ = ctx.run(test_input(egui::vec2(1200.0, 800.0)), |ctx| {
+            let resp = egui::SidePanel::left("explorer_test_panel")
+                .resizable(true)
+                .show(ctx, |ui| {
+                    ExplorerHeader::new(&mut ws, &mut search, &mut action).show(ui);
+                });
+            panel_width_frame2 = resp.response.rect.width();
+        });
+
+        let _ = ctx.run(test_input(egui::vec2(1200.0, 800.0)), |ctx| {
+            let resp = egui::SidePanel::left("explorer_test_panel")
+                .resizable(true)
+                .show(ctx, |ui| {
+                    ExplorerHeader::new(&mut ws, &mut search, &mut action).show(ui);
+                });
+            panel_width_frame3 = resp.response.rect.width();
+        });
+
+        assert!(
+            (panel_width_frame2 - panel_width_frame1).abs() < 1.0,
+            "Explorer panel width expanded between frame 1 and 2! Width 1: {}, Width 2: {}",
+            panel_width_frame1,
+            panel_width_frame2
+        );
+        assert!(
+            (panel_width_frame3 - panel_width_frame2).abs() < 1.0,
+            "Explorer panel width expanded between frame 2 and 3! Width 2: {}, Width 3: {}",
+            panel_width_frame2,
+            panel_width_frame3
+        );
+    }
+}

--- a/crates/katana-ui/src/views/panels/explorer/mod.rs
+++ b/crates/katana-ui/src/views/panels/explorer/mod.rs
@@ -13,3 +13,4 @@ pub mod types;
 pub(crate) use breadcrumb::*;
 pub(crate) use panel::*;
 pub use types::*;
+mod header_tests;


### PR DESCRIPTION
緊急対応第2弾。AlignCenterとshrink_to_fitによるレイアウト再計算ループをテストでRED確認後、GREENになるようにレイアウト制約を解除し修正。