### PR TITLE
fix(ci): winget komac インストールに正しいHomebrewフォーミュラを使用する

### DIFF
--- a/scripts/release/sync-external.sh
+++ b/scripts/release/sync-external.sh
@@ -44,7 +44,7 @@ else
     # We check if komac is available, otherwise try to install it
     if ! command -v komac &> /dev/null; then
         echo "📦 Installing komac..."
-        brew install nicehash/tap/komac 2>/dev/null || true
+        brew install komac 2>/dev/null || true
     fi
 
     if ! command -v komac &> /dev/null; then


### PR DESCRIPTION
## Summary
- `sync-external.sh` の komac インストールコマンドが存在しないtap `nicehash/tap/komac` を使用していた
- `2>/dev/null || true` でエラーが握りつぶされ、komacが未インストールのままwinget syncがスキップされていた
- homebrew-coreの公式フォーミュラ `brew install komac` に修正

## Root Cause
CI v0.22.2リリースログ:
```
📦 Installing komac...
⚠️ komac not found, skipping winget sync.
```

## Test plan
- [ ] 次回リリース時に `🪟 Updating Winget package...` が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)