### PR TITLE
feat(scripts): 汎用 screenshot runner を scripts/screenshot に実装する

### DIFF
--- a/scripts/screenshot/.gitignore
+++ b/scripts/screenshot/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/scripts/screenshot/Cargo.toml
+++ b/scripts/screenshot/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+
+[package]
+name = "katana-screenshot"
+version = "0.1.0"
+edition = "2021"
+description = "Generic screenshot runner for KatanA — invoked by katana-astro or other website tooling"
+
+[[bin]]
+name = "katana-screenshot"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+tempfile = "3"

--- a/scripts/screenshot/examples/workspace-main.json
+++ b/scripts/screenshot/examples/workspace-main.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "1",
+  "name": "workspace-main",
+  "fixture": {
+    "settings": {
+      "theme": "dark",
+      "locale": "en"
+    },
+    "workspace_files": [
+      {
+        "name": "README.md",
+        "content": "# Welcome to KatanA\n\nA native Markdown workspace.\n\n## Features\n\n- Live split-view preview\n- Diagram rendering (Mermaid, PlantUML, Draw.io)\n- Tab-based multi-document editing\n- Full i18n (EN / JA)\n"
+      },
+      {
+        "name": "diagrams.md",
+        "content": "# Diagrams\n\n```mermaid\ngraph TD\n    A[Write Markdown] --> B[Live Preview]\n    B --> C[Export]\n```\n"
+      }
+    ]
+  },
+  "steps": [
+    {
+      "type": "launch",
+      "viewport": { "width": 1280, "height": 800 },
+      "wait_seconds": 3.0
+    },
+    {
+      "type": "screenshot",
+      "output_name": "workspace-main"
+    },
+    {
+      "type": "quit"
+    }
+  ]
+}

--- a/scripts/screenshot/run.sh
+++ b/scripts/screenshot/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# KatanA screenshot runner entry point.
+#
+# Builds the katana-screenshot binary (if needed) and executes a request file.
+#
+# Usage:
+#   ./run.sh --request <request.json> --output <output_dir> --binary <path/to/KatanA>
+#
+# Requirements (macOS):
+#   - Rust toolchain (cargo)
+#   - Accessibility permission granted to Terminal / the shell process
+#     (System Settings > Privacy & Security > Accessibility)
+#
+# Requirements (Linux):
+#   - Rust toolchain (cargo)
+#   - scrot or ImageMagick (import) for screenshot capture
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v cargo &>/dev/null; then
+  echo "ERROR: cargo not found — install Rust via https://rustup.rs" >&2
+  exit 1
+fi
+
+echo "[katana-screenshot] building runner..."
+cargo build --release --manifest-path "${SCRIPT_DIR}/Cargo.toml" --quiet
+
+RUNNER="${SCRIPT_DIR}/target/release/katana-screenshot"
+
+exec "$RUNNER" "$@"

--- a/scripts/screenshot/src/capture.rs
+++ b/scripts/screenshot/src/capture.rs
@@ -1,0 +1,102 @@
+use anyhow::{bail, Result};
+use std::path::Path;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+pub fn screenshot(process_name: &str, output: &Path) -> Result<()> {
+    if cfg!(target_os = "macos") {
+        capture_macos(process_name, output)
+    } else if cfg!(target_os = "linux") {
+        capture_linux(output)
+    } else {
+        bail!("screenshot capture is not supported on this platform")
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn capture_macos(process_name: &str, output: &Path) -> Result<()> {
+    let bounds = wait_for_window_bounds_macos(process_name, 10)?;
+    let region = format!("{},{},{},{}", bounds.0, bounds.1, bounds.2, bounds.3);
+    let status = Command::new("screencapture")
+        .args(["-R", &region, &output.display().to_string()])
+        .status()?;
+    anyhow::ensure!(status.success(), "screencapture exited with {status}");
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn capture_macos(_process_name: &str, _output: &Path) -> Result<()> {
+    bail!("macOS capture called on non-macOS platform")
+}
+
+#[cfg(target_os = "linux")]
+fn capture_linux(output: &Path) -> Result<()> {
+    // Try scrot first, then import (ImageMagick) as fallback
+    if which("scrot") {
+        let status = Command::new("scrot")
+            .args(["--focused", &output.display().to_string()])
+            .status()?;
+        anyhow::ensure!(status.success(), "scrot exited with {status}");
+    } else if which("import") {
+        let status = Command::new("import")
+            .args(["-window", "root", &output.display().to_string()])
+            .status()?;
+        anyhow::ensure!(status.success(), "import exited with {status}");
+    } else {
+        bail!("no screenshot tool found; install scrot or ImageMagick");
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn capture_linux(_output: &Path) -> Result<()> {
+    bail!("Linux capture called on non-Linux platform")
+}
+
+#[cfg(target_os = "linux")]
+fn which(cmd: &str) -> bool {
+    Command::new("which").arg(cmd).output().map_or(false, |o| o.status.success())
+}
+
+fn wait_for_window_bounds_macos(
+    process_name: &str,
+    timeout_secs: u64,
+) -> Result<(i32, i32, i32, i32)> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        if let Some(bounds) = query_window_bounds_macos(process_name) {
+            return Ok(bounds);
+        }
+        if std::time::Instant::now() >= deadline {
+            bail!("KatanA window not found within {timeout_secs}s");
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+}
+
+fn query_window_bounds_macos(process_name: &str) -> Option<(i32, i32, i32, i32)> {
+    let script = format!(
+        r#"tell application "System Events"
+    set procs to (every process whose name is "{process_name}")
+    if procs is {{}} then return ""
+    set proc to first item of procs
+    if (count of windows of proc) is 0 then return ""
+    set win to first window of proc
+    set {{x, y}} to position of win
+    set {{w, h}} to size of win
+    return (x as string) & "," & (y as string) & "," & (w as string) & "," & (h as string)
+end tell"#
+    );
+    let out = Command::new("osascript").arg("-e").arg(&script).output().ok()?;
+    let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    let parts: Vec<i32> = raw.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+    if parts.len() == 4 && parts[2] > 0 && parts[3] > 0 {
+        Some((parts[0], parts[1], parts[2], parts[3]))
+    } else {
+        None
+    }
+}

--- a/scripts/screenshot/src/executor.rs
+++ b/scripts/screenshot/src/executor.rs
@@ -1,0 +1,116 @@
+use crate::{capture, request::Step};
+use anyhow::{bail, Result};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::thread;
+use std::time::Duration;
+
+pub struct Session {
+    binary: PathBuf,
+    home_dir: PathBuf,
+    child: Option<Child>,
+}
+
+impl Session {
+    pub fn new(binary: &Path, home_dir: &Path) -> Self {
+        Self {
+            binary: binary.to_owned(),
+            home_dir: home_dir.to_owned(),
+            child: None,
+        }
+    }
+
+    pub fn is_running(&mut self) -> bool {
+        self.child.as_mut().map_or(false, |c| c.try_wait().ok().flatten().is_none())
+    }
+
+    pub fn launch(&mut self, viewport: Option<(u32, u32)>, wait_secs: f64) -> Result<()> {
+        let mut cmd = Command::new(&self.binary);
+        cmd.env("HOME", &self.home_dir);
+
+        if cfg!(target_os = "linux") {
+            cmd.env("XDG_CONFIG_HOME", self.home_dir.join(".config"));
+        }
+        if let Some((w, h)) = viewport {
+            cmd.env("KATANA_SCREENSHOT_WIDTH", w.to_string());
+            cmd.env("KATANA_SCREENSHOT_HEIGHT", h.to_string());
+        }
+        cmd.stdout(std::process::Stdio::null()).stderr(std::process::Stdio::null());
+
+        let child = cmd.spawn()?;
+        println!("  launched KatanA (pid={})", child.id());
+        self.child = Some(child);
+
+        thread::sleep(Duration::from_secs_f64(wait_secs));
+        Ok(())
+    }
+
+    pub fn quit(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+            println!("  KatanA quit");
+        }
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.quit();
+    }
+}
+
+pub fn run(
+    steps: &[Step],
+    output_dir: &Path,
+    binary: &Path,
+    home_dir: &Path,
+) -> Result<()> {
+    let mut session = Session::new(binary, home_dir);
+
+    for (i, step) in steps.iter().enumerate() {
+        let label = step_label(step);
+        println!("step {}/{}: {label}", i + 1, steps.len());
+
+        match step {
+            Step::Launch(s) => {
+                let vp = s.viewport.map(|v| (v.width, v.height));
+                session.launch(vp, s.wait_seconds)?;
+            }
+            Step::Wait(s) => {
+                println!("  sleeping {:.1}s", s.seconds);
+                thread::sleep(Duration::from_secs_f64(s.seconds));
+            }
+            Step::Screenshot(s) => {
+                if !session.is_running() {
+                    bail!("screenshot step requires a running KatanA (add a 'launch' step first)");
+                }
+                let out = output_dir.join(format!("{}.png", s.output_name));
+                capture::screenshot("KatanA", &out)?;
+                println!("  saved: {}", out.display());
+            }
+            Step::OpenFile(s) => {
+                if !session.is_running() {
+                    bail!("open_file step requires a running KatanA");
+                }
+                println!("  NOTE: place {:?} in fixture.workspace_files — KatanA auto-loads the workspace on launch", s.file_name);
+                thread::sleep(Duration::from_secs_f64(s.wait_seconds));
+            }
+            Step::Quit => {
+                session.quit();
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn step_label(step: &Step) -> &'static str {
+    match step {
+        Step::Launch(_) => "launch",
+        Step::Wait(_) => "wait",
+        Step::Screenshot(_) => "screenshot",
+        Step::OpenFile(_) => "open_file",
+        Step::Quit => "quit",
+    }
+}

--- a/scripts/screenshot/src/fixture.rs
+++ b/scripts/screenshot/src/fixture.rs
@@ -1,0 +1,70 @@
+use crate::request::{Fixture, FixtureSettings};
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+pub struct FixtureEnv {
+    pub home_dir: PathBuf,
+}
+
+pub fn setup(fixture: &Fixture, tmp_root: &Path) -> Result<FixtureEnv> {
+    let home_dir = tmp_root.join("home");
+    let workspace_dir = tmp_root.join("workspace");
+    std::fs::create_dir_all(&home_dir)?;
+    std::fs::create_dir_all(&workspace_dir)?;
+
+    let workspace_dir = match &fixture.workspace_dir {
+        Some(p) => {
+            let resolved = PathBuf::from(p).canonicalize()
+                .with_context(|| format!("fixture.workspace_dir not found: {p}"))?;
+            anyhow::ensure!(resolved.is_dir(), "fixture.workspace_dir is not a directory: {p}");
+            resolved
+        }
+        None => {
+            for wf in &fixture.workspace_files {
+                let dest = workspace_dir.join(&wf.name);
+                std::fs::write(&dest, &wf.content)
+                    .with_context(|| format!("writing fixture file {}", wf.name))?;
+            }
+            workspace_dir
+        }
+    };
+
+    let settings_dir = config_dir(&home_dir);
+    std::fs::create_dir_all(&settings_dir)?;
+    let settings_json = build_settings_json(&fixture.settings, &workspace_dir);
+    std::fs::write(settings_dir.join("settings.json"), settings_json)?;
+
+    Ok(FixtureEnv { home_dir })
+}
+
+fn config_dir(home: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home.join("Library").join("Application Support").join("KatanA")
+    } else if cfg!(target_os = "windows") {
+        home.join("AppData").join("Roaming").join("KatanA")
+    } else {
+        home.join(".config").join("KatanA")
+    }
+}
+
+fn build_settings_json(settings: &FixtureSettings, workspace_dir: &Path) -> String {
+    let theme_str = settings.theme.as_deref().unwrap_or("dark");
+    let locale = settings.locale.as_deref().unwrap_or("en");
+    let preset = if theme_str == "light" { "KatanaLight" } else { "KatanaDark" };
+    let workspace_str = workspace_dir.display();
+
+    format!(
+        r#"{{
+  "version": "0.22.0",
+  "terms_accepted_version": "1.0",
+  "language": "{locale}",
+  "theme": {{
+    "theme": "{theme_str}",
+    "preset": "{preset}"
+  }},
+  "workspace": {{
+    "last_workspace": "{workspace_str}"
+  }}
+}}"#
+    )
+}

--- a/scripts/screenshot/src/main.rs
+++ b/scripts/screenshot/src/main.rs
@@ -1,0 +1,45 @@
+mod capture;
+mod executor;
+mod fixture;
+mod request;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "katana-screenshot", about = "Generic screenshot runner for KatanA")]
+struct Cli {
+    #[arg(long, value_name = "FILE", help = "Path to request JSON file")]
+    request: PathBuf,
+    #[arg(long, value_name = "DIR", help = "Output directory for PNG files")]
+    output: PathBuf,
+    #[arg(long, value_name = "PATH", help = "Path to the KatanA binary")]
+    binary: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let request_path = cli.request.canonicalize()
+        .with_context(|| format!("request file not found: {}", cli.request.display()))?;
+    let binary_path = cli.binary.canonicalize()
+        .with_context(|| format!("KatanA binary not found: {}", cli.binary.display()))?;
+
+    let req = request::load(&request_path)?;
+
+    std::fs::create_dir_all(&cli.output)
+        .with_context(|| format!("cannot create output dir: {}", cli.output.display()))?;
+    let output_dir = cli.output.canonicalize()?;
+
+    println!("[katana-screenshot] request: {}", req.name);
+    println!("[katana-screenshot] output:  {}", output_dir.display());
+
+    let tmp_dir = tempfile::Builder::new().prefix("katana-screenshot-").tempdir()?;
+    let env = fixture::setup(&req.fixture, tmp_dir.path())?;
+
+    executor::run(&req.steps, &output_dir, &binary_path, &env.home_dir)?;
+
+    println!("[katana-screenshot] done");
+    Ok(())
+}

--- a/scripts/screenshot/src/request.rs
+++ b/scripts/screenshot/src/request.rs
@@ -1,0 +1,95 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Request {
+    pub schema_version: String,
+    pub name: String,
+    #[serde(default)]
+    pub fixture: Fixture,
+    pub steps: Vec<Step>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Fixture {
+    #[serde(default)]
+    pub workspace_files: Vec<WorkspaceFile>,
+    pub workspace_dir: Option<String>,
+    #[serde(default)]
+    pub settings: FixtureSettings,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceFile {
+    pub name: String,
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct FixtureSettings {
+    pub theme: Option<String>,
+    pub locale: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Step {
+    Launch(LaunchStep),
+    Wait(WaitStep),
+    Screenshot(ScreenshotStep),
+    OpenFile(OpenFileStep),
+    Quit,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LaunchStep {
+    pub viewport: Option<Viewport>,
+    #[serde(default = "default_wait_seconds")]
+    pub wait_seconds: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WaitStep {
+    pub seconds: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScreenshotStep {
+    pub output_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenFileStep {
+    pub file_name: String,
+    #[serde(default = "default_open_file_wait")]
+    pub wait_seconds: f64,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+pub struct Viewport {
+    pub width: u32,
+    pub height: u32,
+}
+
+fn default_wait_seconds() -> f64 {
+    3.0
+}
+
+fn default_open_file_wait() -> f64 {
+    1.0
+}
+
+const SUPPORTED_SCHEMA_VERSION: &str = "1";
+
+pub fn load(path: &std::path::Path) -> anyhow::Result<Request> {
+    let json = std::fs::read_to_string(path)?;
+    let req: Request = serde_json::from_str(&json)?;
+    anyhow::ensure!(
+        req.schema_version == SUPPORTED_SCHEMA_VERSION,
+        "unsupported schema_version {:?}, expected {:?}",
+        req.schema_version,
+        SUPPORTED_SCHEMA_VERSION,
+    );
+    anyhow::ensure!(!req.name.is_empty(), "request.name must not be empty");
+    anyhow::ensure!(!req.steps.is_empty(), "request.steps must not be empty");
+    Ok(req)
+}


### PR DESCRIPTION
## Summary

- `scripts/screenshot/` に standalone Rust プロジェクト (`katana-screenshot`) を追加
- versioned request JSON file + output directory を受け取り PNG を出力する汎用 CLI を実装
- crates には含めず `./scripts` 配下に留め、website 固有知識を一切持ち込まない設計

## Changes

### `scripts/screenshot/`

| ファイル | 役割 |
|---|---|
| `Cargo.toml` | standalone Rust プロジェクト (`[workspace]` で親から独立) |
| `run.sh` | `cargo build` → バイナリ exec するエントリーポイント |
| `src/main.rs` | CLI 引数解析 (`--request`, `--output`, `--binary`) |
| `src/request.rs` | request JSON のデシリアライズ + schema_version バリデーション |
| `src/fixture.rs` | 一時 HOME / workspace を構築し settings.json を注入 |
| `src/executor.rs` | step sequence の実行 (launch / wait / screenshot / open_file / quit) |
| `src/capture.rs` | macOS: osascript でウィンドウ座標取得 + screencapture -R、Linux: scrot/import fallback |
| `examples/workspace-main.json` | 基本的なリクエストファイルの例 |

### I/O 契約

```
./scripts/screenshot/run.sh \
  --request <request.json> \
  --output <output_dir> \
  --binary <path/to/KatanA>
```

request JSON (`schema_version: "1"`) で fixture / steps を宣言的に記述するだけで再取得が可能。

## Test plan

- [ ] `cargo build` がエラーなく通る (`scripts/screenshot/` 内で独立してビルドできる)
- [ ] `--help` でヘルプが表示される
- [ ] KatanA バイナリを指定して実際に PNG が出力される (手動)
- [ ] checkout path 不正時 (`--binary` が存在しない場合) に即 fail する

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)