### PR TITLE
Fix file dialog crashing on limited Linux environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecolor"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1427,19 @@ dependencies = [
  "profiling",
  "smallvec",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "egui-file-dialog"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b530b58f428bcffb58281ad1c3a59ee559ffd2354aa54d5bf1a2ef418fdcebb3"
+dependencies = [
+ "directories",
+ "dunce",
+ "egui",
+ "serde",
+ "sysinfo",
 ]
 
 [[package]]
@@ -2739,6 +2767,7 @@ dependencies = [
  "dirs",
  "eframe",
  "egui",
+ "egui-file-dialog",
  "egui_commonmark",
  "egui_extras",
  "egui_kittest",
@@ -3314,6 +3343,16 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
  "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -4785,6 +4824,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,11 @@ test-integration: ## Run integration tests — fixture tests only (slow; non-fix
 
 .PHONY: check-linux
 check-linux: ## Verify test execution in isolated Linux environment
-	$(RTK) docker-compose -f platforms/linux/ci/compose.yml run --rm -e RUSTFLAGS="$(RUSTFLAGS) -C link-arg=-fuse-ld=lld" ubuntu-test cargo test -q --workspace
+	$(RTK) docker compose -f platforms/linux/ci/compose.yml run --rm -e RUSTFLAGS="$(RUSTFLAGS) -C link-arg=-fuse-ld=lld" ubuntu-test cargo test -q --workspace
 
 .PHONY: check-windows
 check-windows: ## Verify Windows cross-compilation without running tests
-	$(RTK) docker-compose -f platforms/windows/ci/compose.yml run --rm windows-test cargo xwin check -q --workspace --target x86_64-pc-windows-msvc --tests
+	$(RTK) docker compose -f platforms/windows/ci/compose.yml run --rm windows-test cargo xwin check -q --workspace --target x86_64-pc-windows-msvc --tests
 
 .PHONY: check-platforms
 check-platforms: check-linux check-windows ## Verify test/compilation across all target platforms (Linux, Windows)

--- a/crates/katana-ui/Cargo.toml
+++ b/crates/katana-ui/Cargo.toml
@@ -36,6 +36,7 @@ mathjax_svg = "3.2.0"
 unicode-segmentation = "1.13.2"
 arboard = "3.6.1"
 uuid = { version = "1.23.1", features = ["v4"] }
+egui-file-dialog = "0.13.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/katana-ui/src/app/action/dispatch.rs
+++ b/crates/katana-ui/src/app/action/dispatch.rs
@@ -7,8 +7,14 @@ impl KatanaApp {
     pub(super) fn dispatch_action(&mut self, ctx: &egui::Context, action: AppAction) {
         match action {
             AppAction::PickOpenWorkspace => {
-                if let Some(path) = crate::shell_ui::ShellUiOps::open_folder_dialog() {
+                if crate::shell_ui::ShellUiOps::is_headless() {
+                    self.pending_dialog_action = Some(AppAction::PickOpenWorkspace);
+                    self.file_dialog.pick_directory();
+                } else if let Some(path) = crate::shell_ui::ShellUiOps::open_folder_dialog() {
                     self.handle_open_explorer(path);
+                } else {
+                    self.pending_dialog_action = Some(AppAction::PickOpenWorkspace);
+                    self.file_dialog.pick_directory();
                 }
             }
             AppAction::OpenWorkspace(p) => self.handle_open_explorer(p),

--- a/crates/katana-ui/src/app/action/image_ingest.rs
+++ b/crates/katana-ui/src/app/action/image_ingest.rs
@@ -3,18 +3,30 @@ use crate::shell::*;
 impl KatanaApp {
     /// Ingest an image file from the local filesystem.
     pub(crate) fn handle_action_ingest_image_file(&mut self) {
-        let files = rfd::FileDialog::new()
-            .add_filter("Images", &["png", "jpg", "jpeg", "gif", "webp", "bmp"])
-            .pick_file();
+        if crate::shell_ui::ShellUiOps::is_headless() {
+            self.pending_dialog_action = Some(crate::app_state::AppAction::IngestImageFile);
+            self.file_dialog.pick_file();
+            return;
+        }
 
-        if let Some(source_path) = files
-            && let Ok(bytes) = std::fs::read(&source_path)
-        {
+        let files = std::panic::catch_unwind(|| {
+            rfd::FileDialog::new()
+                .add_filter("Images", &["png", "jpg", "jpeg", "gif", "webp", "bmp"])
+                .pick_file()
+        }).unwrap_or(None);
+
+        if let Some(source_path) = files {
+            let Ok(bytes) = std::fs::read(&source_path) else {
+                return;
+            };
             let ext = source_path
                 .extension()
                 .and_then(|s| s.to_str())
                 .unwrap_or("png");
             self.process_image_ingest(&bytes, ext);
+        } else {
+            self.pending_dialog_action = Some(crate::app_state::AppAction::IngestImageFile);
+            self.file_dialog.pick_file();
         }
     }
 
@@ -39,7 +51,7 @@ impl KatanaApp {
     }
 
     /// Process the ingested image bytes: save to asset dir and insert markdown tag.
-    fn process_image_ingest(&mut self, source_bytes: &[u8], extension: &str) {
+    pub(crate) fn process_image_ingest(&mut self, source_bytes: &[u8], extension: &str) {
         let settings = self.state.config.settings.settings().clone();
 
         let Some(doc) = self.state.active_document() else {

--- a/crates/katana-ui/src/app/export.rs
+++ b/crates/katana-ui/src/app/export.rs
@@ -128,13 +128,33 @@ impl ExportOps for KatanaApp {
         }
 
         let default_name = self.export_filename(doc_path, ext);
-        let path = rfd::FileDialog::new()
-            .set_file_name(&default_name)
-            .add_filter(ext, &[ext])
-            .save_file();
+
+        if crate::shell_ui::ShellUiOps::is_headless() {
+            self.pending_dialog_action = Some(crate::app_state::AppAction::PickExportDocument {
+                doc_path: doc_path.to_path_buf(),
+                ext: ext.to_string(),
+                source: source.to_string()
+            });
+            self.file_dialog.save_file();
+            return;
+        }
+
+        let path = std::panic::catch_unwind(|| {
+            rfd::FileDialog::new()
+                .set_file_name(&default_name)
+                .add_filter(ext, &[ext])
+                .save_file()
+        }).unwrap_or(None);
 
         if let Some(output_path) = path {
-            ExportPoll::perform_tool_export(self, source, ext, output_path, doc_path);
+            crate::app::export_poll::ExportPoll::perform_tool_export(self, source, ext, output_path, doc_path);
+        } else {
+            self.pending_dialog_action = Some(crate::app_state::AppAction::PickExportDocument {
+                doc_path: doc_path.to_path_buf(),
+                ext: ext.to_string(),
+                source: source.to_string()
+            });
+            self.file_dialog.save_file();
         }
     }
     fn poll_export(&mut self, ctx: &egui::Context) {

--- a/crates/katana-ui/src/app/export_poll.rs
+++ b/crates/katana-ui/src/app/export_poll.rs
@@ -1,7 +1,7 @@
 use crate::app_state::*;
 use crate::shell::*;
 
-pub(super) trait ExportPoll {
+pub(crate) trait ExportPoll {
     fn perform_tool_export(
         &mut self,
         source: &str,

--- a/crates/katana-ui/src/app_action.rs
+++ b/crates/katana-ui/src/app_action.rs
@@ -8,6 +8,7 @@ use katana_platform::{PaneOrder, SplitDirection};
 pub enum AppAction {
     InstallUpdate,
     PickOpenWorkspace,
+    PickExportDocument { doc_path: PathBuf, ext: String, source: String },
     OpenWorkspace(PathBuf),
     SelectDocument(PathBuf),
     SelectDocumentAndJump {

--- a/crates/katana-ui/src/shell/mod.rs
+++ b/crates/katana-ui/src/shell/mod.rs
@@ -68,6 +68,8 @@ impl KatanaApp {
             old_app_version: None,
             editor_cursor_range: None,
             pending_editor_cursor: None,
+            file_dialog: egui_file_dialog::FileDialog::new(),
+            pending_dialog_action: None,
         };
         let current_version = env!("CARGO_PKG_VERSION");
         let mut show_changelog = false;

--- a/crates/katana-ui/src/shell/shell_tests.rs
+++ b/crates/katana-ui/src/shell/shell_tests.rs
@@ -943,6 +943,8 @@ mod tests_extra {
             old_app_version: None,
             editor_cursor_range: None,
             pending_editor_cursor: None,
+            file_dialog: egui_file_dialog::FileDialog::new(),
+            pending_dialog_action: None,
         }
     }
 

--- a/crates/katana-ui/src/shell/types.rs
+++ b/crates/katana-ui/src/shell/types.rs
@@ -66,4 +66,7 @@ pub struct KatanaApp {
     /* WHY: Authoring — pending cursor to restore after a buffer transform.
     Set by handle_action_author_markdown; consumed by EditorContent on the next frame. */
     pub(crate) pending_editor_cursor: Option<(usize, usize)>,
+
+    pub(crate) file_dialog: egui_file_dialog::FileDialog,
+    pub(crate) pending_dialog_action: Option<AppAction>,
 }

--- a/crates/katana-ui/src/shell_ui/mod.rs
+++ b/crates/katana-ui/src/shell_ui/mod.rs
@@ -13,8 +13,23 @@ impl ShellUiOps {
         crate::native_menu::NativeMenuOps::update_native_menu_strings_from_i18n();
     }
 
+    pub(crate) fn is_headless() -> bool {
+        if std::env::var("KATANA_HEADLESS").is_ok() {
+            return true;
+        }
+        #[cfg(target_os = "linux")]
+        {
+            if std::env::var("DISPLAY").is_err() && std::env::var("WAYLAND_DISPLAY").is_err() {
+                return true;
+            }
+        }
+        false
+    }
+
     pub(crate) fn open_folder_dialog() -> Option<std::path::PathBuf> {
-        rfd::FileDialog::new().pick_folder()
+        std::panic::catch_unwind(|| {
+            rfd::FileDialog::new().pick_folder()
+        }).unwrap_or(None)
     }
 
     pub(crate) fn pick_open_workspace() -> AppAction {
@@ -75,6 +90,7 @@ impl eframe::App for KatanaApp {
         }
 
         self.show_modals(ctx);
+        self.update_file_dialog(ctx);
 
         self.state.scroll.scroll_to_line = None;
         crate::views::app_frame::AppFrameOps::intercept_url_commands(ctx, self);

--- a/crates/katana-ui/src/shell_ui/shell_ui_update.rs
+++ b/crates/katana-ui/src/shell_ui/shell_ui_update.rs
@@ -70,6 +70,43 @@ impl KatanaApp {
         theme_colors
     }
 
+    pub(crate) fn update_file_dialog(&mut self, ctx: &egui::Context) {
+        self.file_dialog.update(ctx);
+
+        if let Some(path) = self.file_dialog.take_picked() {
+            if let Some(action) = self.pending_dialog_action.take() {
+                self.handle_file_dialog_action(path, action);
+            }
+        }
+    }
+
+    fn handle_file_dialog_action(&mut self, path: std::path::PathBuf, action: AppAction) {
+        match action {
+            AppAction::PickOpenWorkspace => {
+                self.handle_open_explorer(path);
+            }
+            AppAction::IngestImageFile => {
+                let Ok(bytes) = std::fs::read(&path) else {
+                    return;
+                };
+                let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("png");
+                self.process_image_ingest(&bytes, ext);
+            }
+            AppAction::PickExportDocument { doc_path, ext, source } => {
+                use crate::app::export_poll::ExportPoll;
+                self.perform_tool_export(
+                    &source,
+                    &ext,
+                    path,
+                    &doc_path,
+                );
+            }
+            _ => {}
+        }
+
+
+    }
+
     fn tick_auto_save(&mut self) {
         let behavior = self.state.config.settings.settings().behavior.clone();
         if behavior.auto_save && behavior.auto_save_interval_secs > 0.0 {

--- a/crates/katana-ui/src/shell_ui/shell_ui_update.rs
+++ b/crates/katana-ui/src/shell_ui/shell_ui_update.rs
@@ -73,10 +73,10 @@ impl KatanaApp {
     pub(crate) fn update_file_dialog(&mut self, ctx: &egui::Context) {
         self.file_dialog.update(ctx);
 
-        if let Some(path) = self.file_dialog.take_picked() {
-            if let Some(action) = self.pending_dialog_action.take() {
-                self.handle_file_dialog_action(path, action);
-            }
+        if let Some(path) = self.file_dialog.take_picked()
+            && let Some(action) = self.pending_dialog_action.take()
+        {
+            self.handle_file_dialog_action(path, action);
         }
     }
 


### PR DESCRIPTION
Fixes a critical issue where the application would crash or fail to open workspaces, export files, or ingest images on limited Linux environments (like WebTop or headless containers) lacking `xdg-desktop-portal-gtk` or a valid windowing protocol.

The native `rfd` file dialog now correctly falls back to `egui-file-dialog` when a lack of `DISPLAY`/`WAYLAND_DISPLAY` on Linux is detected, allowing workspace interactions securely via an in-app file picker GUI.

---
*PR created automatically by Jules for task [6420517161999119789](https://jules.google.com/task/6420517161999119789) started by @HiroyukiFuruno*