### PR TITLE
feat(v0.22.5): Task 2-4 — 画像ペースト・参照画像表示・ingest設定

### DIFF
--- a/crates/katana-ui/locales/de.json
+++ b/crates/katana-ui/locales/de.json
@@ -93,7 +93,8 @@
     "open_workspace_button": "Ordner öffnen",
     "remove_history_tooltip": "Aus Verlauf entfernen",
     "max_depth_exceeded": "Maximale Tiefe überschritten",
-    "filter_hint": "Filtern…"
+    "filter_hint": "Filtern…",
+    "referenced_images_section": "Referenzierte Bilder"
   },
   "preview": {
     "preview_title": "Vorschau",
@@ -386,7 +387,11 @@
       "cache_retention_days": "Aufbewahrung (Tage)",
       "days_suffix": " Tage",
       "toc_default_visible": "Inhaltsverzeichnis beim Start anzeigen",
-      "explorer_default_visible": "Explorer beim Start anzeigen"
+      "explorer_default_visible": "Explorer beim Start anzeigen",
+      "ingest_section_title": "Bildimport",
+      "ingest_image_save_directory": "Bildspeicherverzeichnis",
+      "ingest_image_name_format": "Bildnamenformat",
+      "ingest_create_directory": "Verzeichnis erstellen, wenn nicht vorhanden"
     },
     "general": "Allgemein",
     "shortcuts": {

--- a/crates/katana-ui/locales/en.json
+++ b/crates/katana-ui/locales/en.json
@@ -93,7 +93,8 @@
     "open_folder_hint": "Open a folder to start using KatanA.",
     "open_workspace_button": "Open Workspace",
     "remove_history_tooltip": "Remove from history",
-    "max_depth_exceeded": "Max depth exceeded"
+    "max_depth_exceeded": "Max depth exceeded",
+    "referenced_images_section": "Referenced Images"
   },
   "preview": {
     "preview_title": "Preview",
@@ -397,7 +398,11 @@
       "cache_retention_days": "Cache Retention (Days)",
       "days_suffix": " Days",
       "toc_default_visible": "Show Table of Contents on startup",
-      "explorer_default_visible": "Show Explorer on startup"
+      "explorer_default_visible": "Show Explorer on startup",
+      "ingest_section_title": "Image Ingest",
+      "ingest_image_save_directory": "Image Save Directory",
+      "ingest_image_name_format": "Image Name Format",
+      "ingest_create_directory": "Create directory if not exists"
     },
     "general": "General"
   },

--- a/crates/katana-ui/locales/es.json
+++ b/crates/katana-ui/locales/es.json
@@ -93,7 +93,8 @@
     "open_workspace_button": "Abrir carpeta",
     "remove_history_tooltip": "Quitar del historial",
     "max_depth_exceeded": "Profundidad máxima excedida",
-    "filter_hint": "Filtrar…"
+    "filter_hint": "Filtrar…",
+    "referenced_images_section": "Imágenes referenciadas"
   },
   "preview": {
     "preview_title": "Vista previa",
@@ -386,7 +387,11 @@
       "cache_retention_days": "Días de retención",
       "days_suffix": " días",
       "toc_default_visible": "Mostrar tabla de contenidos al iniciar",
-      "explorer_default_visible": "Mostrar explorador al iniciar"
+      "explorer_default_visible": "Mostrar explorador al iniciar",
+      "ingest_section_title": "Importación de imagen",
+      "ingest_image_save_directory": "Directorio de guardado",
+      "ingest_image_name_format": "Formato del nombre de imagen",
+      "ingest_create_directory": "Crear directorio si no existe"
     },
     "general": "Generalidad",
     "shortcuts": {

--- a/crates/katana-ui/locales/fr.json
+++ b/crates/katana-ui/locales/fr.json
@@ -93,7 +93,8 @@
     "open_workspace_button": "Ouvrir un dossier",
     "remove_history_tooltip": "Supprimer de l'historique",
     "max_depth_exceeded": "Profondeur maximale dépassée",
-    "filter_hint": "Filtrer…"
+    "filter_hint": "Filtrer…",
+    "referenced_images_section": "Images référencées"
   },
   "preview": {
     "preview_title": "Aperçu",
@@ -386,7 +387,11 @@
       "cache_retention_days": "Rétention (jours)",
       "days_suffix": " jours",
       "toc_default_visible": "Afficher la table des matières au démarrage",
-      "explorer_default_visible": "Afficher l'explorateur au démarrage"
+      "explorer_default_visible": "Afficher l'explorateur au démarrage",
+      "ingest_section_title": "Importation d'image",
+      "ingest_image_save_directory": "Répertoire de sauvegarde",
+      "ingest_image_name_format": "Format du nom d'image",
+      "ingest_create_directory": "Créer le répertoire s'il n'existe pas"
     },
     "general": "Général",
     "shortcuts": {

--- a/crates/katana-ui/locales/it.json
+++ b/crates/katana-ui/locales/it.json
@@ -93,7 +93,8 @@
     "open_workspace_button": "Apri cartella",
     "remove_history_tooltip": "Rimuovi dalla cronologia",
     "max_depth_exceeded": "Profondità massima superata",
-    "filter_hint": "Filtra…"
+    "filter_hint": "Filtra…",
+    "referenced_images_section": "Immagini referenziate"
   },
   "preview": {
     "preview_title": "Anteprima",
@@ -386,7 +387,11 @@
       "cache_retention_days": "Giorni ritenzione",
       "days_suffix": " giorni",
       "toc_default_visible": "Mostra sommario all'avvio",
-      "explorer_default_visible": "Mostra esploratore all'avvio"
+      "explorer_default_visible": "Mostra esploratore all'avvio",
+      "ingest_section_title": "Importazione immagine",
+      "ingest_image_save_directory": "Directory di salvataggio",
+      "ingest_image_name_format": "Formato nome immagine",
+      "ingest_create_directory": "Crea directory se non esiste"
     },
     "general": "Generale",
     "shortcuts": {

--- a/crates/katana-ui/locales/ja.json
+++ b/crates/katana-ui/locales/ja.json
@@ -93,7 +93,8 @@
     "open_folder_hint": "KatanAを使い始めるために、フォルダを開いてください。",
     "open_workspace_button": "ワークスペースを開く",
     "remove_history_tooltip": "履歴から除去",
-    "max_depth_exceeded": "最大深度を超過しました"
+    "max_depth_exceeded": "最大深度を超過しました",
+    "referenced_images_section": "参照画像"
   },
   "preview": {
     "preview_title": "プレビュー",
@@ -397,7 +398,11 @@
       "cache_retention_days": "キャッシュ保持日数",
       "days_suffix": " 日",
       "toc_default_visible": "起動時に目次を表示する",
-      "explorer_default_visible": "起動時にエクスプローラーを表示する"
+      "explorer_default_visible": "起動時にエクスプローラーを表示する",
+      "ingest_section_title": "画像の取り込み",
+      "ingest_image_save_directory": "画像の保存先",
+      "ingest_image_name_format": "画像ファイル名の形式",
+      "ingest_create_directory": "保存先フォルダが存在しない場合は作成する"
     },
     "general": "全般"
   },

--- a/crates/katana-ui/locales/ko.json
+++ b/crates/katana-ui/locales/ko.json
@@ -93,7 +93,8 @@
     "open_workspace_button": "폴더 열기",
     "remove_history_tooltip": "기록에서 제거",
     "max_depth_exceeded": "최대 스캔 깊이를 초과했습니다",
-    "filter_hint": "필터…"
+    "filter_hint": "필터…",
+    "referenced_images_section": "참조 이미지"
   },
   "preview": {
     "preview_title": "미리보기",
@@ -386,7 +387,11 @@
       "cache_retention_days": "캐시 보존 기간",
       "days_suffix": " 일",
       "toc_default_visible": "시작 시 목차 표시",
-      "explorer_default_visible": "시작 시 탐색기 표시"
+      "explorer_default_visible": "시작 시 탐색기 표시",
+      "ingest_section_title": "이미지 가져오기",
+      "ingest_image_save_directory": "이미지 저장 디렉토리",
+      "ingest_image_name_format": "이미지 이름 형식",
+      "ingest_create_directory": "디렉토리가 없으면 생성"
     },
     "general": "일반",
     "shortcuts": {

--- a/crates/katana-ui/locales/pt.json
+++ b/crates/katana-ui/locales/pt.json
@@ -93,7 +93,8 @@
     "open_workspace_button": "Abrir pasta",
     "remove_history_tooltip": "Remover do histórico",
     "max_depth_exceeded": "Profundidade máxima excedida",
-    "filter_hint": "Filtragem…"
+    "filter_hint": "Filtragem…",
+    "referenced_images_section": "Imagens referenciadas"
   },
   "preview": {
     "preview_title": "Visualização",
@@ -386,7 +387,11 @@
       "cache_retention_days": "Dias de retenção",
       "days_suffix": " dias",
       "toc_default_visible": "Mostrar índice ao iniciar",
-      "explorer_default_visible": "Mostrar explorador ao iniciar"
+      "explorer_default_visible": "Mostrar explorador ao iniciar",
+      "ingest_section_title": "Importação de imagem",
+      "ingest_image_save_directory": "Diretório de salvamento",
+      "ingest_image_name_format": "Formato do nome da imagem",
+      "ingest_create_directory": "Criar diretório se não existir"
     },
     "general": "Geral",
     "shortcuts": {

--- a/crates/katana-ui/locales/zh-CN.json
+++ b/crates/katana-ui/locales/zh-CN.json
@@ -93,7 +93,8 @@
     "open_workspace_button": "打开文件夹",
     "remove_history_tooltip": "从历史记录中移除",
     "max_depth_exceeded": "超过最大扫描深度",
-    "filter_hint": "过滤…"
+    "filter_hint": "过滤…",
+    "referenced_images_section": "引用图像"
   },
   "preview": {
     "preview_title": "预览",
@@ -386,7 +387,11 @@
       "cache_retention_days": "缓存保留天数",
       "days_suffix": " 天",
       "toc_default_visible": "启动时显示目录",
-      "explorer_default_visible": "启动时显示资源管理器"
+      "explorer_default_visible": "启动时显示资源管理器",
+      "ingest_section_title": "图像导入",
+      "ingest_image_save_directory": "图像保存目录",
+      "ingest_image_name_format": "图像名称格式",
+      "ingest_create_directory": "目录不存在时自动创建"
     },
     "general": "通用",
     "shortcuts": {

--- a/crates/katana-ui/locales/zh-TW.json
+++ b/crates/katana-ui/locales/zh-TW.json
@@ -93,7 +93,8 @@
     "open_workspace_button": "開啟資料夾",
     "remove_history_tooltip": "從歷史記錄中移除",
     "max_depth_exceeded": "超過最大掃描深度",
-    "filter_hint": "篩選…"
+    "filter_hint": "篩選…",
+    "referenced_images_section": "引用圖像"
   },
   "preview": {
     "preview_title": "預覽",
@@ -386,7 +387,11 @@
       "cache_retention_days": "快取保留天數",
       "days_suffix": " 天",
       "toc_default_visible": "啟動時顯示目錄",
-      "explorer_default_visible": "啟動時顯示檔案總管"
+      "explorer_default_visible": "啟動時顯示檔案總管",
+      "ingest_section_title": "圖像匯入",
+      "ingest_image_save_directory": "圖像儲存目錄",
+      "ingest_image_name_format": "圖像名稱格式",
+      "ingest_create_directory": "目錄不存在時自動建立"
     },
     "general": "一般",
     "shortcuts": {

--- a/crates/katana-ui/src/i18n/types/settings.rs
+++ b/crates/katana-ui/src/i18n/types/settings.rs
@@ -167,26 +167,20 @@ pub struct SettingsUpdateMessages {
     pub plantuml_update_now: String,
 }
 
+#[rustfmt::skip]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SettingsBehaviorMessages {
-    pub section_title: String,
-    pub confirm_close_dirty_tab: String,
-    pub scroll_sync: String,
-    pub auto_save: String,
-    pub auto_save_interval: String,
-    pub auto_save_interval_hint: String,
-    pub auto_refresh: String,
-    pub auto_refresh_interval: String,
-    pub seconds: String,
-    pub close_confirm_title: String,
-    pub close_confirm_msg: String,
-    pub close_confirm_discard: String,
-    pub close_confirm_cancel: String,
-    pub clear_http_cache: String,
-    pub cache_retention_days: String,
-    pub days_suffix: String,
-    pub toc_default_visible: String,
-    pub explorer_default_visible: String,
+    pub section_title: String, pub confirm_close_dirty_tab: String,
+    pub scroll_sync: String, pub auto_save: String,
+    pub auto_save_interval: String, pub auto_save_interval_hint: String,
+    pub auto_refresh: String, pub auto_refresh_interval: String,
+    pub seconds: String, pub close_confirm_title: String,
+    pub close_confirm_msg: String, pub close_confirm_discard: String,
+    pub close_confirm_cancel: String, pub clear_http_cache: String,
+    pub cache_retention_days: String, pub days_suffix: String,
+    pub toc_default_visible: String, pub explorer_default_visible: String,
+    pub ingest_section_title: String, pub ingest_image_save_directory: String,
+    pub ingest_image_name_format: String, pub ingest_create_directory: String,
 }
 
 #[rustfmt::skip]

--- a/crates/katana-ui/src/i18n/types/workspace.rs
+++ b/crates/katana-ui/src/i18n/types/workspace.rs
@@ -19,4 +19,5 @@ pub struct WorkspaceMessages {
     pub open_workspace_button: String,
     pub remove_history_tooltip: String,
     pub max_depth_exceeded: String,
+    pub referenced_images_section: String,
 }

--- a/crates/katana-ui/src/settings/tabs/behavior/ingest.rs
+++ b/crates/katana-ui/src/settings/tabs/behavior/ingest.rs
@@ -1,0 +1,75 @@
+use crate::app_state::AppState;
+use crate::settings::*;
+use eframe::egui;
+
+pub struct BehaviorIngestOps;
+
+impl BehaviorIngestOps {
+    pub(super) fn render(ui: &mut egui::Ui, state: &mut AppState) {
+        let msgs = &crate::i18n::I18nOps::get().settings.behavior;
+
+        ui.label(egui::RichText::new(&msgs.ingest_section_title).strong());
+        ui.add_space(SETTINGS_TOGGLE_SPACING);
+
+        let mut save_dir = state
+            .config
+            .settings
+            .settings()
+            .ingest
+            .image_save_directory
+            .clone();
+        ui.label(&msgs.ingest_image_save_directory);
+        if ui.text_edit_singleline(&mut save_dir).changed() {
+            state
+                .config
+                .settings
+                .settings_mut()
+                .ingest
+                .image_save_directory = save_dir;
+            let _ = state.config.try_save_settings();
+        }
+        ui.add_space(SETTINGS_TOGGLE_SPACING);
+
+        let mut name_format = state
+            .config
+            .settings
+            .settings()
+            .ingest
+            .image_name_format
+            .clone();
+        ui.label(&msgs.ingest_image_name_format);
+        if ui.text_edit_singleline(&mut name_format).changed() {
+            state
+                .config
+                .settings
+                .settings_mut()
+                .ingest
+                .image_name_format = name_format;
+            let _ = state.config.try_save_settings();
+        }
+        ui.add_space(SETTINGS_TOGGLE_SPACING);
+
+        let mut create_dir = state
+            .config
+            .settings
+            .settings()
+            .ingest
+            .create_directory_if_not_exists;
+        if ui
+            .add(
+                crate::widgets::LabeledToggle::new(&msgs.ingest_create_directory, &mut create_dir)
+                    .position(crate::widgets::TogglePosition::Right)
+                    .alignment(crate::widgets::ToggleAlignment::SpaceBetween),
+            )
+            .changed()
+        {
+            state
+                .config
+                .settings
+                .settings_mut()
+                .ingest
+                .create_directory_if_not_exists = create_dir;
+            let _ = state.config.try_save_settings();
+        }
+    }
+}

--- a/crates/katana-ui/src/settings/tabs/behavior/mod.rs
+++ b/crates/katana-ui/src/settings/tabs/behavior/mod.rs
@@ -3,6 +3,7 @@ use crate::app_state::AppAction;
 use crate::settings::*;
 
 mod editor;
+mod ingest;
 
 impl BehaviorTabOps {
     pub(crate) fn render_behavior_tab(
@@ -10,6 +11,8 @@ impl BehaviorTabOps {
         state: &mut crate::app_state::AppState,
     ) -> Option<AppAction> {
         editor::BehaviorEditorOps::render(ui, state);
+        ui.add_space(SUBSECTION_SPACING);
+        ingest::BehaviorIngestOps::render(ui, state);
         ui.add_space(SUBSECTION_SPACING);
 
         let behavior_msgs = &crate::i18n::I18nOps::get().settings.behavior;

--- a/crates/katana-ui/src/state/command_inventory/edit_commands.rs
+++ b/crates/katana-ui/src/state/command_inventory/edit_commands.rs
@@ -163,7 +163,7 @@ impl EditCommands {
                 context: ShortcutContext::Editor,
                 label: || I18nOps::get().search.command_ingest_clipboard_image.clone(),
                 is_available: |state| is_active_editable_markdown(state),
-                default_shortcuts: &[],
+                default_shortcuts: &["primary+shift+V"],
             },
         ]
     }

--- a/crates/katana-ui/src/views/app_frame/sidebar/explorer/hover.rs
+++ b/crates/katana-ui/src/views/app_frame/sidebar/explorer/hover.rs
@@ -64,6 +64,21 @@ impl ExplorerHoverOverlay {
                         .settings()
                         .layout
                         .accordion_vertical_line;
+                    let referenced_images = app
+                        .state
+                        .document
+                        .active_doc_idx
+                        .and_then(|idx| app.state.document.open_documents.get(idx))
+                        .filter(|doc| !doc.is_reference && !doc.path.as_os_str().is_empty())
+                        .map(|doc| {
+                            let (_, paths) =
+                                katana_core::preview::ImagePreviewOps::resolve_image_paths(
+                                    &doc.buffer,
+                                    &doc.path,
+                                );
+                            paths
+                        })
+                        .unwrap_or_default();
                     crate::views::panels::explorer::ExplorerPanel::new(
                         &mut app.state.workspace,
                         &mut app.state.search,
@@ -73,6 +88,7 @@ impl ExplorerHoverOverlay {
                         &mut app.pending_action,
                         show_vertical_line,
                     )
+                    .with_referenced_images(referenced_images)
                     .show(ui);
                 });
             });

--- a/crates/katana-ui/src/views/app_frame/sidebar/explorer/ui.rs
+++ b/crates/katana-ui/src/views/app_frame/sidebar/explorer/ui.rs
@@ -73,6 +73,21 @@ impl<'a> ExplorerSidebar<'a> {
                         .settings()
                         .layout
                         .accordion_vertical_line;
+                    let referenced_images = app
+                        .state
+                        .document
+                        .active_doc_idx
+                        .and_then(|idx| app.state.document.open_documents.get(idx))
+                        .filter(|doc| !doc.is_reference && !doc.path.as_os_str().is_empty())
+                        .map(|doc| {
+                            let (_, paths) =
+                                katana_core::preview::ImagePreviewOps::resolve_image_paths(
+                                    &doc.buffer,
+                                    &doc.path,
+                                );
+                            paths
+                        })
+                        .unwrap_or_default();
                     crate::views::panels::explorer::ExplorerPanel::new(
                         &mut app.state.workspace,
                         &mut app.state.search,
@@ -82,6 +97,7 @@ impl<'a> ExplorerSidebar<'a> {
                         &mut app.pending_action,
                         show_vertical_line,
                     )
+                    .with_referenced_images(referenced_images)
                     .show(ui);
                 });
 

--- a/crates/katana-ui/src/views/panels/editor/logic.rs
+++ b/crates/katana-ui/src/views/panels/editor/logic.rs
@@ -39,6 +39,30 @@ impl EditorLogicOps {
                 *action = AppAction::SaveDocument;
                 ui.close_menu();
             }
+            if ui
+                .button(
+                    crate::i18n::I18nOps::get()
+                        .search
+                        .command_ingest_clipboard_image
+                        .as_str(),
+                )
+                .clicked()
+            {
+                *action = AppAction::IngestClipboardImage;
+                ui.close_menu();
+            }
+            if ui
+                .button(
+                    crate::i18n::I18nOps::get()
+                        .search
+                        .command_ingest_image_file
+                        .as_str(),
+                )
+                .clicked()
+            {
+                *action = AppAction::IngestImageFile;
+                ui.close_menu();
+            }
         });
     }
 

--- a/crates/katana-ui/src/views/panels/explorer/content.rs
+++ b/crates/katana-ui/src/views/panels/explorer/content.rs
@@ -13,6 +13,7 @@ pub(crate) struct ExplorerContent<'a> {
     pub tab_groups: &'a [crate::state::document::TabGroup],
     pub action: &'a mut AppAction,
     pub show_vertical_line: bool,
+    pub referenced_images: Vec<std::path::PathBuf>,
 }
 
 impl<'a> ExplorerContent<'a> {
@@ -33,7 +34,13 @@ impl<'a> ExplorerContent<'a> {
             tab_groups,
             action,
             show_vertical_line,
+            referenced_images: Vec::new(),
         }
+    }
+
+    pub fn with_referenced_images(mut self, images: Vec<std::path::PathBuf>) -> Self {
+        self.referenced_images = images;
+        self
     }
 
     pub fn show(self, ui: &mut egui::Ui) {
@@ -51,6 +58,7 @@ impl<'a> ExplorerContent<'a> {
     fn show_active_workspace(self, ui: &mut egui::Ui) {
         let (workspace, search, active_path, action) =
             (self.workspace, self.search, self.active_path, self.action);
+        let referenced_images = self.referenced_images;
         let ws = workspace.data.as_ref().unwrap();
         let entries = ws.tree.clone();
         let ws_root = ws.root.clone();
@@ -85,6 +93,12 @@ impl<'a> ExplorerContent<'a> {
                         TreeEntryNode::new(entry, &mut ctx).show(ui);
                     }
                 }
+
+                super::referenced_images::ReferencedImagesSection::new(
+                    &referenced_images,
+                    ctx.action,
+                )
+                .show(ui);
             });
     }
 

--- a/crates/katana-ui/src/views/panels/explorer/mod.rs
+++ b/crates/katana-ui/src/views/panels/explorer/mod.rs
@@ -6,6 +6,7 @@ pub mod file_entry;
 pub mod header;
 pub mod logic;
 pub mod panel;
+pub mod referenced_images;
 pub mod shared;
 pub mod tree_entry;
 pub mod types;

--- a/crates/katana-ui/src/views/panels/explorer/panel.rs
+++ b/crates/katana-ui/src/views/panels/explorer/panel.rs
@@ -14,6 +14,7 @@ pub(crate) struct ExplorerPanel<'a> {
     pub tab_groups: &'a [crate::state::document::TabGroup],
     pub action: &'a mut AppAction,
     pub show_vertical_line: bool,
+    pub referenced_images: Vec<std::path::PathBuf>,
 }
 
 impl<'a> ExplorerPanel<'a> {
@@ -34,7 +35,13 @@ impl<'a> ExplorerPanel<'a> {
             tab_groups,
             action,
             show_vertical_line,
+            referenced_images: Vec::new(),
         }
+    }
+
+    pub fn with_referenced_images(mut self, images: Vec<std::path::PathBuf>) -> Self {
+        self.referenced_images = images;
+        self
     }
 
     pub fn show(self, ui: &mut egui::Ui) {
@@ -76,6 +83,7 @@ impl<'a> ExplorerPanel<'a> {
                 action,
                 self.show_vertical_line,
             )
+            .with_referenced_images(self.referenced_images)
             .show(ui);
         }
     }

--- a/crates/katana-ui/src/views/panels/explorer/referenced_images.rs
+++ b/crates/katana-ui/src/views/panels/explorer/referenced_images.rs
@@ -1,0 +1,43 @@
+use crate::app_state::AppAction;
+use eframe::egui;
+
+pub(crate) struct ReferencedImagesSection<'a> {
+    pub paths: &'a [std::path::PathBuf],
+    pub action: &'a mut AppAction,
+}
+
+impl<'a> ReferencedImagesSection<'a> {
+    pub fn new(paths: &'a [std::path::PathBuf], action: &'a mut AppAction) -> Self {
+        Self { paths, action }
+    }
+
+    pub fn show(self, ui: &mut egui::Ui) {
+        if self.paths.is_empty() {
+            return;
+        }
+        ui.separator();
+        let section_label = &crate::i18n::I18nOps::get()
+            .workspace
+            .referenced_images_section;
+        egui::CollapsingHeader::new(section_label.as_str())
+            .default_open(true)
+            .show(ui, |ui| {
+                for path in self.paths {
+                    let name = path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    let resp = ui.add(
+                        egui::Label::new(&name)
+                            .truncate()
+                            .selectable(false)
+                            .sense(egui::Sense::click()),
+                    );
+                    if resp.clicked() {
+                        *self.action = AppAction::RevealImageAsset(path.clone());
+                    }
+                    resp.on_hover_text(path.to_string_lossy().as_ref());
+                }
+            });
+    }
+}

--- a/openspec/changes/v0-22-5-code-input-improvements/tasks.md
+++ b/openspec/changes/v0-22-5-code-input-improvements/tasks.md
@@ -22,19 +22,19 @@
 
 マークダウンエディタに視覚的な書式設定ボタンを追加し、キーボードショートカットだけでなく GUI 操作も可能にする。
 
-- [ ] 1.1 システム SVG 基盤のボタンコンポーネントを `crates/katana-ui/src/components/buttons/` に実装
-- [ ] 1.2 太字、斜体、見出し、リスト、コードなど一般的な Markdown 書式のボタンを追加
-- [ ] 1.3 エディタ上部にツールバーを表示（コンテキスト認識型）
-- [ ] 1.4 テキスト選択状態に応じてボタンの有効/無効を切り替え
-- [ ] 1.5 ショートカットキーとの統合（ボタンクリックとキー操作の両方で動作）
+- [x] 1.1 システム SVG 基盤のボタンコンポーネントを `crates/katana-ui/src/views/panels/editor/toolbar.rs` に実装
+- [x] 1.2 太字、斜体、見出し、リスト、コードなど一般的な Markdown 書式のボタンを追加
+- [x] 1.3 エディタ上部にツールバーを表示（コンテキスト認識型、AlignCenter ウィジェットで水平配置）
+- [x] 1.4 テキスト選択状態に応じてボタンの有効/無効を切り替え
+- [x] 1.5 ショートカットキーとの統合（ボタンクリックとキー操作の両方で動作）
 
 ### Definition of Done (DoD)
 
-- [ ] トールバーから Markdown 書式設定が可能であること
-- [ ] 選択テキストに応じてボタンが有効/無効に切り替わる 것
-- [ ] ショートカットキーと同等の動作を確認
-- [ ] `make check` がエラーなし (exit code 0) で通過すること
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+- [x] ツールバーから Markdown 書式設定が可能であること
+- [x] 選択テキストに応じてボタンが有効/無効に切り替わる
+- [x] ショートカットキーと同等の動作を確認
+- [x] `make check` がエラーなし (exit code 0) で通過すること
+- [x] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ---
 


### PR DESCRIPTION
## Summary

- **Task 2**: エディタ右クリックメニューにクリップボード画像貼り付け (Cmd+Shift+V) / 画像ファイル添付を追加
- **Task 3**: エクスプローラーに参照画像セクションを追加（アクティブドキュメントの画像一覧・クリックで表示）
- **Task 4**: 設定画面 Behavior タブに画像 ingest 設定（保存先・命名形式・ディレクトリ作成）を追加

## Changes

- `editor/logic.rs`: 右クリックメニューに「クリップボードから画像を貼り付け」「画像ファイルを添付」追加
- `edit_commands.rs`: `ingest_clipboard_image` に `Cmd+Shift+V` ショートカット設定
- `explorer/referenced_images.rs`: 新規 — 参照画像一覧ウィジェット
- `explorer/panel.rs`, `content.rs`: builder パターン化 (too_many_arguments 解消)
- `settings/tabs/behavior/ingest.rs`: 新規 — ingest 設定 UI
- 全10ロケールに i18n キーを追加

## Test plan

- [x] `make check` 全チェック通過 (lint / test / coverage / Windows cross-compile)