### PR TITLE
fix(editor): 入力回帰と画像貼り付け導線を修正

### DIFF
--- a/crates/katana-ui/src/app/document.rs
+++ b/crates/katana-ui/src/app/document.rs
@@ -5,6 +5,7 @@ use crate::shell::*;
 
 use crate::app::doc_close::DocCloseOps;
 use crate::app::doc_search::DocSearchRefresh;
+use crate::app::document_scroll::DocumentScrollOps;
 use crate::preview_pane::{DownloadRequest, PreviewPane};
 use crate::shell_logic::ShellLogicOps;
 use katana_platform::FilesystemService;
@@ -21,6 +22,8 @@ pub(crate) trait DocumentOps {
 
 impl DocumentOps for KatanaApp {
     fn handle_select_document(&mut self, path: std::path::PathBuf, activate: bool) {
+        let previous_active_path = self.state.active_path();
+
         if activate {
             let mut parent = path.parent();
             while let Some(p) = parent {
@@ -35,7 +38,6 @@ impl DocumentOps for KatanaApp {
             }
         }
 
-        /* WHY: Check if already open. If so, just activate if requested. */
         if let Some(idx) = self
             .state
             .document
@@ -45,8 +47,8 @@ impl DocumentOps for KatanaApp {
         {
             if activate {
                 self.state.document.active_doc_idx = Some(idx);
+                self.reset_scroll_for_new_active_path(&previous_active_path, &path);
 
-                /* WHY: Load if needed. */
                 let doc_is_loaded = self.state.document.open_documents[idx].is_loaded;
                 if !doc_is_loaded
                     && !path.to_string_lossy().starts_with("Katana://")
@@ -74,7 +76,6 @@ impl DocumentOps for KatanaApp {
             return;
         }
 
-        /* WHY: Not open yet. Load and add to open documents. */
         let doc = if activate {
             match self.fs.load_document(&path) {
                 Ok(d) => d,
@@ -105,6 +106,7 @@ impl DocumentOps for KatanaApp {
         self.state.document.open_documents.push(doc);
         if activate {
             self.state.document.active_doc_idx = Some(self.state.document.open_documents.len() - 1);
+            self.reset_scroll_for_new_active_path(&previous_active_path, &path);
             if search_open {
                 /* WHY: Refresh search matches only when activating a document.
                 Background loading must not disrupt the current UI state. */

--- a/crates/katana-ui/src/app/document_scroll.rs
+++ b/crates/katana-ui/src/app/document_scroll.rs
@@ -1,0 +1,14 @@
+use crate::shell::KatanaApp;
+use std::path::{Path, PathBuf};
+
+pub(crate) trait DocumentScrollOps {
+    fn reset_scroll_for_new_active_path(&mut self, previous: &Option<PathBuf>, next: &Path);
+}
+
+impl DocumentScrollOps for KatanaApp {
+    fn reset_scroll_for_new_active_path(&mut self, previous: &Option<PathBuf>, next: &Path) {
+        if previous.as_deref() != Some(next) {
+            self.state.scroll.reset_for_document_change();
+        }
+    }
+}

--- a/crates/katana-ui/src/app/mod.rs
+++ b/crates/katana-ui/src/app/mod.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod doc_close;
 pub mod doc_search;
 pub mod document;
+pub(crate) mod document_scroll;
 pub mod download;
 pub mod export;
 pub mod export_poll;

--- a/crates/katana-ui/src/app/workspace/open/session.rs
+++ b/crates/katana-ui/src/app/workspace/open/session.rs
@@ -178,6 +178,7 @@ impl WorkspaceOpenSessionOps {
                 .unwrap_or(0)
                 .min(app.state.document.open_documents.len() - 1);
             app.state.document.active_doc_idx = Some(idx);
+            app.state.scroll.reset_for_document_change();
             let src = app.state.document.open_documents[idx].buffer.clone();
             let doc_path = app.state.document.open_documents[idx].path.clone();
             let concurrency = app

--- a/crates/katana-ui/src/app_state.rs
+++ b/crates/katana-ui/src/app_state.rs
@@ -112,6 +112,18 @@ impl AppState {
                     .find(|t| t.path == doc.path)
                     .map(|t| t.mode)
             })
-            .unwrap_or(ViewMode::PreviewOnly)
+            .unwrap_or_else(|| {
+                self.active_document()
+                    .map(Self::default_view_mode_for_document)
+                    .unwrap_or(ViewMode::PreviewOnly)
+            })
+    }
+
+    fn default_view_mode_for_document(doc: &Document) -> ViewMode {
+        if doc.is_reference || doc.path.to_string_lossy().starts_with("Katana://") {
+            ViewMode::PreviewOnly
+        } else {
+            ViewMode::CodeOnly
+        }
     }
 }

--- a/crates/katana-ui/src/shell_ui/mod.rs
+++ b/crates/katana-ui/src/shell_ui/mod.rs
@@ -5,6 +5,7 @@ use eframe::egui;
 mod shell_ui_frame;
 mod shell_ui_shortcuts;
 mod shell_ui_update;
+mod shortcut_keys;
 mod types;
 pub use types::ShellUiOps;
 

--- a/crates/katana-ui/src/shell_ui/shell_ui_shortcuts.rs
+++ b/crates/katana-ui/src/shell_ui/shell_ui_shortcuts.rs
@@ -1,111 +1,8 @@
+use super::shortcut_keys::ShortcutKeyOps;
 use crate::shell::KatanaApp;
 use crate::state::command_inventory::{CommandInventory, CommandInventoryItem};
 use crate::state::shortcut_context::{ShortcutContext, ShortcutContextResolver};
 use eframe::egui;
-
-/// WHY: Strips the legacy `[editor]` context suffix from shortcut strings.
-/// This suffix was used before ShortcutContext was introduced to hint that
-/// a shortcut belongs to the editor. The suffix is now deprecated — context
-/// is encoded in CommandInventoryItem::context — but we still strip it to
-/// avoid parse failures for any user-customized shortcuts that may still
-/// carry the old format in their persisted settings.
-fn strip_context_suffix(s: &str) -> &str {
-    s.strip_suffix("[editor]").unwrap_or(s)
-}
-
-fn parse_shortcut(s: &str) -> Option<egui::KeyboardShortcut> {
-    let clean = strip_context_suffix(s);
-    let mut modifiers = egui::Modifiers::NONE;
-    let mut key = None;
-
-    for part in clean.split('+') {
-        let p = part.trim().to_lowercase();
-        match p.as_str() {
-            "primary" | "cmd" | "command" => modifiers.command = true,
-            "ctrl" => modifiers.ctrl = true,
-            "shift" => modifiers.shift = true,
-            "alt" | "option" => modifiers.alt = true,
-            "mac_cmd" | "win" | "super" | "meta" => modifiers.mac_cmd = true,
-            _ => {
-                key = parse_key(&p);
-            }
-        }
-    }
-
-    key.map(|k| egui::KeyboardShortcut::new(modifiers, k))
-}
-
-fn parse_key(s: &str) -> Option<egui::Key> {
-    match s {
-        "a" => Some(egui::Key::A),
-        "b" => Some(egui::Key::B),
-        "c" => Some(egui::Key::C),
-        "d" => Some(egui::Key::D),
-        "e" => Some(egui::Key::E),
-        "f" => Some(egui::Key::F),
-        "g" => Some(egui::Key::G),
-        "h" => Some(egui::Key::H),
-        "i" => Some(egui::Key::I),
-        "j" => Some(egui::Key::J),
-        "k" => Some(egui::Key::K),
-        "l" => Some(egui::Key::L),
-        "m" => Some(egui::Key::M),
-        "n" => Some(egui::Key::N),
-        "o" => Some(egui::Key::O),
-        "p" => Some(egui::Key::P),
-        "q" => Some(egui::Key::Q),
-        "r" => Some(egui::Key::R),
-        "s" => Some(egui::Key::S),
-        "t" => Some(egui::Key::T),
-        "u" => Some(egui::Key::U),
-        "v" => Some(egui::Key::V),
-        "w" => Some(egui::Key::W),
-        "x" => Some(egui::Key::X),
-        "y" => Some(egui::Key::Y),
-        "z" => Some(egui::Key::Z),
-        "0" => Some(egui::Key::Num0),
-        "1" => Some(egui::Key::Num1),
-        "2" => Some(egui::Key::Num2),
-        "3" => Some(egui::Key::Num3),
-        "4" => Some(egui::Key::Num4),
-        "5" => Some(egui::Key::Num5),
-        "6" => Some(egui::Key::Num6),
-        "7" => Some(egui::Key::Num7),
-        "8" => Some(egui::Key::Num8),
-        "9" => Some(egui::Key::Num9),
-        "," => Some(egui::Key::Comma),
-        "." => Some(egui::Key::Period),
-        "/" => Some(egui::Key::Slash),
-        "\\" | "¥" => Some(egui::Key::Backslash),
-        "-" => Some(egui::Key::Minus),
-        "=" => Some(egui::Key::Equals),
-        ";" | "semicolon" => Some(egui::Key::Semicolon),
-        ":" | "colon" => Some(egui::Key::Colon),
-        "{" => Some(egui::Key::OpenCurlyBracket),
-        "}" => Some(egui::Key::CloseCurlyBracket),
-        "[" => Some(egui::Key::OpenBracket),
-        "]" => Some(egui::Key::CloseBracket),
-        "`" => Some(egui::Key::Backtick),
-        "@" => Some(egui::Key::OpenBracket),
-        "^" => Some(egui::Key::Equals),
-        "_" => Some(egui::Key::Minus),
-        "space" => Some(egui::Key::Space),
-        "enter" => Some(egui::Key::Enter),
-        "esc" | "escape" => Some(egui::Key::Escape),
-        "tab" => Some(egui::Key::Tab),
-        "|" => Some(egui::Key::Pipe),
-        "?" => Some(egui::Key::Questionmark),
-        "!" => Some(egui::Key::Exclamationmark),
-        "\"" | "'" | "quote" => Some(egui::Key::Quote),
-        "backspace" => Some(egui::Key::Backspace),
-        "delete" => Some(egui::Key::Delete),
-        "up" => Some(egui::Key::ArrowUp),
-        "down" => Some(egui::Key::ArrowDown),
-        "left" => Some(egui::Key::ArrowLeft),
-        "right" => Some(egui::Key::ArrowRight),
-        _ => None,
-    }
-}
 
 impl KatanaApp {
     pub(super) fn handle_shortcuts(&mut self, ctx: &egui::Context) {
@@ -171,17 +68,11 @@ impl KatanaApp {
                     .collect()
             };
 
-            let mut matched = false;
-            for raw_shortcut in shortcuts_to_try {
-                if let Some(parsed) = parse_shortcut(&raw_shortcut)
-                    && ctx.input_mut(|i| i.consume_shortcut(&parsed))
-                {
-                    self.pending_action = cmd.action.clone();
-                    matched = true;
-                    break;
-                }
-            }
-            if matched {
+            if shortcuts_to_try
+                .iter()
+                .any(|raw_shortcut| command_shortcut_consumed(ctx, active_context, raw_shortcut))
+            {
+                self.pending_action = cmd.action.clone();
                 /* WHY: Stop processing after the first match to prevent
                 ambiguous multi-fire within the same frame. */
                 break;
@@ -190,32 +81,16 @@ impl KatanaApp {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn strip_context_suffix_removes_editor_tag() {
-        assert_eq!(strip_context_suffix("primary+B[editor]"), "primary+B");
+fn command_shortcut_consumed(
+    ctx: &egui::Context,
+    active_context: ShortcutContext,
+    raw_shortcut: &str,
+) -> bool {
+    let Some(parsed) = ShortcutKeyOps::parse_shortcut(raw_shortcut) else {
+        return false;
+    };
+    if active_context == ShortcutContext::Editor && ShortcutKeyOps::editor_keeps_shortcut(&parsed) {
+        return false;
     }
-
-    #[test]
-    fn strip_context_suffix_leaves_plain_shortcut_unchanged() {
-        assert_eq!(strip_context_suffix("primary+S"), "primary+S");
-    }
-
-    #[test]
-    fn parse_shortcut_handles_backtick() {
-        let result = parse_shortcut("primary+`");
-        assert!(
-            result.is_some(),
-            "backtick shortcut must parse successfully"
-        );
-    }
-
-    #[test]
-    fn parse_shortcut_ignores_unknown_key() {
-        let result = parse_shortcut("primary+@@@");
-        assert!(result.is_none());
-    }
+    ctx.input_mut(|i| i.consume_shortcut(&parsed))
 }

--- a/crates/katana-ui/src/shell_ui/shortcut_keys.rs
+++ b/crates/katana-ui/src/shell_ui/shortcut_keys.rs
@@ -1,0 +1,151 @@
+use eframe::egui;
+
+/// WHY: Strips the legacy `[editor]` context suffix from shortcut strings.
+/// This suffix was used before ShortcutContext was introduced to hint that
+/// a shortcut belongs to the editor. The suffix is now deprecated — context
+/// is encoded in CommandInventoryItem::context — but we still strip it to
+/// avoid parse failures for any user-customized shortcuts that may still
+/// carry the old format in their persisted settings.
+fn strip_context_suffix(s: &str) -> &str {
+    s.strip_suffix("[editor]").unwrap_or(s)
+}
+
+pub(crate) struct ShortcutKeyOps;
+
+impl ShortcutKeyOps {
+    pub(crate) fn parse_shortcut(s: &str) -> Option<egui::KeyboardShortcut> {
+        let clean = strip_context_suffix(s);
+        let mut modifiers = egui::Modifiers::NONE;
+        let mut key = None;
+
+        for part in clean.split('+') {
+            let p = part.trim().to_lowercase();
+            match p.as_str() {
+                "primary" | "cmd" | "command" => modifiers.command = true,
+                "ctrl" => modifiers.ctrl = true,
+                "shift" => modifiers.shift = true,
+                "alt" | "option" => modifiers.alt = true,
+                "mac_cmd" | "win" | "super" | "meta" => modifiers.mac_cmd = true,
+                _ => {
+                    key = parse_key(&p);
+                }
+            }
+        }
+
+        key.map(|k| egui::KeyboardShortcut::new(modifiers, k))
+    }
+}
+
+fn parse_key(s: &str) -> Option<egui::Key> {
+    match s {
+        "a" => Some(egui::Key::A),
+        "b" => Some(egui::Key::B),
+        "c" => Some(egui::Key::C),
+        "d" => Some(egui::Key::D),
+        "e" => Some(egui::Key::E),
+        "f" => Some(egui::Key::F),
+        "g" => Some(egui::Key::G),
+        "h" => Some(egui::Key::H),
+        "i" => Some(egui::Key::I),
+        "j" => Some(egui::Key::J),
+        "k" => Some(egui::Key::K),
+        "l" => Some(egui::Key::L),
+        "m" => Some(egui::Key::M),
+        "n" => Some(egui::Key::N),
+        "o" => Some(egui::Key::O),
+        "p" => Some(egui::Key::P),
+        "q" => Some(egui::Key::Q),
+        "r" => Some(egui::Key::R),
+        "s" => Some(egui::Key::S),
+        "t" => Some(egui::Key::T),
+        "u" => Some(egui::Key::U),
+        "v" => Some(egui::Key::V),
+        "w" => Some(egui::Key::W),
+        "x" => Some(egui::Key::X),
+        "y" => Some(egui::Key::Y),
+        "z" => Some(egui::Key::Z),
+        "0" => Some(egui::Key::Num0),
+        "1" => Some(egui::Key::Num1),
+        "2" => Some(egui::Key::Num2),
+        "3" => Some(egui::Key::Num3),
+        "4" => Some(egui::Key::Num4),
+        "5" => Some(egui::Key::Num5),
+        "6" => Some(egui::Key::Num6),
+        "7" => Some(egui::Key::Num7),
+        "8" => Some(egui::Key::Num8),
+        "9" => Some(egui::Key::Num9),
+        "," => Some(egui::Key::Comma),
+        "." => Some(egui::Key::Period),
+        "/" => Some(egui::Key::Slash),
+        "\\" | "¥" => Some(egui::Key::Backslash),
+        "-" => Some(egui::Key::Minus),
+        "=" => Some(egui::Key::Equals),
+        ";" | "semicolon" => Some(egui::Key::Semicolon),
+        ":" | "colon" => Some(egui::Key::Colon),
+        "{" => Some(egui::Key::OpenCurlyBracket),
+        "}" => Some(egui::Key::CloseCurlyBracket),
+        "[" => Some(egui::Key::OpenBracket),
+        "]" => Some(egui::Key::CloseBracket),
+        "`" => Some(egui::Key::Backtick),
+        "@" => Some(egui::Key::OpenBracket),
+        "^" => Some(egui::Key::Equals),
+        "_" => Some(egui::Key::Minus),
+        "space" => Some(egui::Key::Space),
+        "enter" => Some(egui::Key::Enter),
+        "esc" | "escape" => Some(egui::Key::Escape),
+        "tab" => Some(egui::Key::Tab),
+        "|" => Some(egui::Key::Pipe),
+        "?" => Some(egui::Key::Questionmark),
+        "!" => Some(egui::Key::Exclamationmark),
+        "\"" | "'" | "quote" => Some(egui::Key::Quote),
+        "backspace" => Some(egui::Key::Backspace),
+        "delete" => Some(egui::Key::Delete),
+        "up" => Some(egui::Key::ArrowUp),
+        "down" => Some(egui::Key::ArrowDown),
+        "left" => Some(egui::Key::ArrowLeft),
+        "right" => Some(egui::Key::ArrowRight),
+        _ => None,
+    }
+}
+
+impl ShortcutKeyOps {
+    pub(crate) fn editor_keeps_shortcut(shortcut: &egui::KeyboardShortcut) -> bool {
+        let key = shortcut.logical_key;
+        let modifiers = shortcut.modifiers;
+
+        if matches!(
+            key,
+            egui::Key::ArrowUp
+                | egui::Key::ArrowDown
+                | egui::Key::ArrowLeft
+                | egui::Key::ArrowRight
+                | egui::Key::Backspace
+                | egui::Key::Delete
+                | egui::Key::Enter
+                | egui::Key::Tab
+        ) {
+            return true;
+        }
+
+        if !modifiers.command {
+            return false;
+        }
+
+        matches!(
+            key,
+            egui::Key::A
+                | egui::Key::B
+                | egui::Key::C
+                | egui::Key::I
+                | egui::Key::K
+                | egui::Key::U
+                | egui::Key::V
+                | egui::Key::X
+                | egui::Key::Y
+                | egui::Key::Z
+        )
+    }
+}
+
+#[cfg(test)]
+include!("shortcut_keys_tests.rs");

--- a/crates/katana-ui/src/shell_ui/shortcut_keys_tests.rs
+++ b/crates/katana-ui/src/shell_ui/shortcut_keys_tests.rs
@@ -1,0 +1,54 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_context_suffix_removes_editor_tag() {
+        assert_eq!(strip_context_suffix("primary+B[editor]"), "primary+B");
+    }
+
+    #[test]
+    fn strip_context_suffix_leaves_plain_shortcut_unchanged() {
+        assert_eq!(strip_context_suffix("primary+S"), "primary+S");
+    }
+
+    #[test]
+    fn parse_shortcut_handles_backtick() {
+        let result = ShortcutKeyOps::parse_shortcut("primary+`");
+        assert!(
+            result.is_some(),
+            "backtick shortcut must parse successfully"
+        );
+    }
+
+    #[test]
+    fn parse_shortcut_ignores_unknown_key() {
+        let result = ShortcutKeyOps::parse_shortcut("primary+@@@");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn editor_keeps_primary_v_for_text_or_image_paste() {
+        let shortcut = ShortcutKeyOps::parse_shortcut("primary+V").expect("primary+V must parse");
+        assert!(ShortcutKeyOps::editor_keeps_shortcut(&shortcut));
+    }
+
+    #[test]
+    fn editor_keeps_shifted_primary_b_for_native_text_entry() {
+        let shortcut =
+            ShortcutKeyOps::parse_shortcut("primary+shift+B").expect("primary+shift+B must parse");
+        assert!(ShortcutKeyOps::editor_keeps_shortcut(&shortcut));
+    }
+
+    #[test]
+    fn editor_does_not_keep_primary_s() {
+        let shortcut = ShortcutKeyOps::parse_shortcut("primary+S").expect("primary+S must parse");
+        assert!(!ShortcutKeyOps::editor_keeps_shortcut(&shortcut));
+    }
+
+    #[test]
+    fn editor_keeps_arrow_navigation() {
+        let shortcut = ShortcutKeyOps::parse_shortcut("shift+left").expect("shift+left must parse");
+        assert!(ShortcutKeyOps::editor_keeps_shortcut(&shortcut));
+    }
+}

--- a/crates/katana-ui/src/state/command_inventory/edit_commands.rs
+++ b/crates/katana-ui/src/state/command_inventory/edit_commands.rs
@@ -17,9 +17,8 @@ impl EditCommands {
     pub fn get() -> Vec<CommandInventoryItem> {
         vec![
             /* WHY: Edit Group — Markdown authoring commands.
-            All edit commands use ShortcutContext::Editor so they only fire
-            when the text editor pane has keyboard focus, preventing conflicts
-            with Global shortcuts that share the same key combinations. */
+            Text-entry shortcut conflicts are filtered by shell_ui_shortcuts;
+            toolbar and command palette routes remain available for protected keys. */
             CommandInventoryItem {
                 id: "edit.bold",
                 action: AppAction::AuthorMarkdown(MarkdownAuthoringOp::Bold),

--- a/crates/katana-ui/src/state/scroll.rs
+++ b/crates/katana-ui/src/state/scroll.rs
@@ -55,4 +55,39 @@ impl ScrollState {
             sync_override: None,
         }
     }
+
+    pub fn reset_for_document_change(&mut self) {
+        let sync_override = self.sync_override;
+        *self = Self {
+            sync_override,
+            ..Self::new()
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_for_document_change_clears_scroll_offsets() {
+        let mut scroll = ScrollState {
+            source: ScrollSource::Editor,
+            editor_y: 320.0,
+            preview_y: 180.0,
+            scroll_to_line: Some(12),
+            last_scroll_to_line: Some(12),
+            sync_override: Some(false),
+            ..Default::default()
+        };
+
+        scroll.reset_for_document_change();
+
+        assert_eq!(scroll.source, ScrollSource::Neither);
+        assert_eq!(scroll.editor_y, 0.0);
+        assert_eq!(scroll.preview_y, 0.0);
+        assert_eq!(scroll.scroll_to_line, None);
+        assert_eq!(scroll.last_scroll_to_line, None);
+        assert_eq!(scroll.sync_override, Some(false));
+    }
 }

--- a/crates/katana-ui/src/views/modals/command_palette.rs
+++ b/crates/katana-ui/src/views/modals/command_palette.rs
@@ -1,7 +1,7 @@
 use super::command_palette_results::{execute_payload, render_results};
 use crate::app_state::AppAction;
 use crate::state::command_palette::{
-    CommandPaletteExecutePayload, CommandPaletteProvider, CommandPaletteState,
+    CommandPaletteExecutePayload, CommandPaletteProvider, CommandPaletteResult, CommandPaletteState,
 };
 use eframe::egui;
 
@@ -39,6 +39,15 @@ const COMMAND_PALETTE_MARGIN: f32 = 8.0;
 const COMMAND_PALETTE_INNER_MARGIN_Y: f32 = 4.0;
 const COMMAND_PALETTE_HINT_OPACITY: f32 = 0.4;
 const COMMAND_PALETTE_PREFIX_OPACITY: f32 = 0.0;
+
+fn command_result_visible_in_normal_palette(result: &CommandPaletteResult) -> bool {
+    matches!(
+        &result.execute_payload,
+        CommandPaletteExecutePayload::DispatchAppAction(
+            AppAction::IngestImageFile | AppAction::IngestClipboardImage
+        )
+    )
+}
 
 pub(crate) struct CommandPaletteModal<'a> {
     pub state: &'a mut CommandPaletteState,
@@ -142,10 +151,16 @@ impl<'a> CommandPaletteModal<'a> {
                         if is_action_mode && provider.name() != "Commands" {
                             continue;
                         }
+                        let results = provider.search(&actual_query, self.workspace, None);
                         if !is_action_mode && provider.name() == "Commands" {
-                            continue;
+                            gathered.extend(
+                                results
+                                    .into_iter()
+                                    .filter(command_result_visible_in_normal_palette),
+                            );
+                        } else {
+                            gathered.extend(results);
                         }
-                        gathered.extend(provider.search(&actual_query, self.workspace, None));
                     }
                     gathered.sort_by(|a, b| {
                         b.score
@@ -165,3 +180,6 @@ impl<'a> CommandPaletteModal<'a> {
         self.state.is_open = is_open;
     }
 }
+
+#[cfg(test)]
+include!("command_palette_tests.rs");

--- a/crates/katana-ui/src/views/modals/command_palette_tests.rs
+++ b/crates/katana-ui/src/views/modals/command_palette_tests.rs
@@ -1,0 +1,38 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::command_palette::CommandPaletteResultKind;
+
+    fn action_result(action: AppAction) -> CommandPaletteResult {
+        CommandPaletteResult {
+            id: "test".to_string(),
+            label: "Test".to_string(),
+            secondary_label: None,
+            shortcut: None,
+            score: 1.0,
+            kind: CommandPaletteResultKind::Action,
+            execute_payload: CommandPaletteExecutePayload::DispatchAppAction(action),
+        }
+    }
+
+    #[test]
+    fn normal_palette_allows_image_file_command() {
+        assert!(command_result_visible_in_normal_palette(&action_result(
+            AppAction::IngestImageFile
+        )));
+    }
+
+    #[test]
+    fn normal_palette_allows_clipboard_image_command() {
+        assert!(command_result_visible_in_normal_palette(&action_result(
+            AppAction::IngestClipboardImage
+        )));
+    }
+
+    #[test]
+    fn normal_palette_hides_unrelated_commands() {
+        assert!(!command_result_visible_in_normal_palette(&action_result(
+            AppAction::ToggleSettings
+        )));
+    }
+}

--- a/crates/katana-ui/src/views/panels/editor/logic.rs
+++ b/crates/katana-ui/src/views/panels/editor/logic.rs
@@ -66,6 +66,57 @@ impl EditorLogicOps {
         });
     }
 
+    pub fn should_ingest_clipboard_image_paste(
+        response_has_focus: bool,
+        text_changed: bool,
+        events: &[egui::Event],
+    ) -> bool {
+        if !response_has_focus || text_changed {
+            return false;
+        }
+
+        let mut paste_signal = false;
+        for event in events {
+            match event {
+                egui::Event::Paste(text) => {
+                    if !text.is_empty() {
+                        return false;
+                    }
+                    paste_signal = true;
+                }
+                egui::Event::Key {
+                    key,
+                    pressed,
+                    repeat,
+                    modifiers,
+                    ..
+                } if *key == egui::Key::V
+                    && *pressed
+                    && !*repeat
+                    && modifiers.command
+                    && !modifiers.shift
+                    && !modifiers.alt =>
+                {
+                    paste_signal = true;
+                }
+                _ => {}
+            }
+        }
+
+        paste_signal
+    }
+
+    pub fn editor_clipboard_image_paste_requested(
+        ui: &egui::Ui,
+        response: &egui::Response,
+        text_changed: bool,
+    ) -> bool {
+        let response_has_focus = response.has_focus();
+        ui.input(|i| {
+            Self::should_ingest_clipboard_image_paste(response_has_focus, text_changed, &i.events)
+        })
+    }
+
     pub fn handle_scroll_to_line(
         ui: &mut egui::Ui,
         scroll: &mut crate::app_state::ScrollState,
@@ -123,6 +174,10 @@ impl EditorLogicOps {
             return;
         }
 
+        if scroll.scroll_to_line.is_some() {
+            return;
+        }
+
         let current_logical = scroll.logical_position;
         let next_logical = scroll.mapper.editor_to_logical(offset_y);
 
@@ -138,3 +193,6 @@ impl EditorLogicOps {
         }
     }
 }
+
+#[cfg(test)]
+include!("logic_tests.rs");

--- a/crates/katana-ui/src/views/panels/editor/logic_tests.rs
+++ b/crates/katana-ui/src/views/panels/editor/logic_tests.rs
@@ -59,7 +59,7 @@ mod tests {
     fn line_range_to_char_range_to_end() {
         let buf = "line0\nline1\nline2";
         let result = EditorLogicOps::line_range_to_char_range(buf, 2, 2);
-        assert_eq!(result, Some((12, 16)));
+        assert_eq!(result, Some((12, 17)));
     }
 
     #[test]
@@ -96,7 +96,7 @@ mod tests {
         };
         EditorLogicOps::update_scroll_sync(&mut scroll, 1000.0, 500.0, 250.0, true, 0.01, vec![]);
         assert_eq!(scroll.source, ScrollSource::Neither);
-        assert!(scroll.editor_echo.is_echo(250.0));
+        assert_eq!(scroll.editor_y, 250.0);
     }
 
     #[test]
@@ -116,7 +116,7 @@ mod tests {
             source: ScrollSource::Neither,
             ..Default::default()
         };
-        scroll.editor_echo.record(250.0);
+        scroll.editor_echo.offset_y = 250.0;
         EditorLogicOps::update_scroll_sync(&mut scroll, 1000.0, 500.0, 251.0, false, 0.01, vec![]);
         assert_eq!(scroll.source, ScrollSource::Neither);
     }
@@ -146,5 +146,45 @@ mod tests {
             "When scroll_to_line is active, source must NOT be set to Editor; \
              otherwise the preview's scroll_request position will be overwritten by mapper"
         );
+    }
+
+    #[test]
+    fn empty_paste_with_focus_requests_clipboard_image_ingest() {
+        let events = vec![egui::Event::Paste(String::new())];
+        assert!(EditorLogicOps::should_ingest_clipboard_image_paste(
+            true, false, &events
+        ));
+    }
+
+    #[test]
+    fn text_paste_does_not_request_clipboard_image_ingest() {
+        let events = vec![egui::Event::Paste("text".to_string())];
+        assert!(!EditorLogicOps::should_ingest_clipboard_image_paste(
+            true, false, &events
+        ));
+    }
+
+    #[test]
+    fn command_v_without_text_requests_clipboard_image_ingest() {
+        let mut modifiers = egui::Modifiers::NONE;
+        modifiers.command = true;
+        let events = vec![egui::Event::Key {
+            key: egui::Key::V,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers,
+        }];
+        assert!(EditorLogicOps::should_ingest_clipboard_image_paste(
+            true, false, &events
+        ));
+    }
+
+    #[test]
+    fn changed_text_does_not_request_clipboard_image_ingest() {
+        let events = vec![egui::Event::Paste(String::new())];
+        assert!(!EditorLogicOps::should_ingest_clipboard_image_paste(
+            true, true, &events
+        ));
     }
     }

--- a/crates/katana-ui/src/views/panels/editor/ui.rs
+++ b/crates/katana-ui/src/views/panels/editor/ui.rs
@@ -10,10 +10,7 @@ pub(crate) struct EditorContent<'a> {
     pub sync_scroll: bool,
     pub doc_search_matches: &'a [std::ops::Range<usize>],
     pub doc_search_active_index: usize,
-    /// Output: receives the cursor range reported by `TextEdit` this frame.
     pub cursor_range_out: &'a mut Option<egui::text::CCursorRange>,
-    /// Input: if set, the `TextEdit` cursor is programmatically moved to this
-    /// char-index range on this frame (used after an authoring transform).
     pub pending_cursor: Option<(usize, usize)>,
 }
 impl<'a> EditorContent<'a> {
@@ -46,7 +43,9 @@ impl<'a> EditorContent<'a> {
         let cursor_range_out = self.cursor_range_out;
         if let Some(doc) = self.document {
             let mut buffer = doc.buffer.clone();
-            super::toolbar::EditorToolbar::render(ui, action, cursor_range_out);
+            if !doc.is_reference {
+                super::toolbar::EditorToolbar::render(ui, action, cursor_range_out);
+            }
             let colors: EditorColors = EditorLogicOps::resolve_editor_colors(ui);
             let (
                 code_bg,
@@ -57,12 +56,11 @@ impl<'a> EditorContent<'a> {
                 ln_text,
                 ln_active_text,
             ) = colors;
-
-            let mut scroll_area = egui::ScrollArea::vertical().id_salt("editor_scroll");
+            let mut scroll_area =
+                egui::ScrollArea::vertical().id_salt(("editor_scroll", &doc.path));
             if scroll.scroll_to_line.is_some() {
                 scroll_area = scroll_area.animated(false);
             }
-
             let consuming_preview = sync_scroll
                 && scroll.source == ScrollSource::Preview
                 && scroll.scroll_to_line.is_none();
@@ -71,14 +69,12 @@ impl<'a> EditorContent<'a> {
                     scroll.mapper.logical_to_editor(scroll.logical_position),
                 );
             }
-
             let output = egui::Frame::NONE.fill(code_bg).show(ui, |ui| {
                 ui.style_mut().visuals.override_text_color = Some(code_text);
                 ui.style_mut().visuals.extreme_bg_color = code_bg;
                 if let Some(sel) = code_selection {
                     ui.style_mut().visuals.selection.bg_fill = sel;
                 }
-
                 scroll_area.show(ui, |ui| {
                     let horiz_response = ui.horizontal_top(|ui| {
                         const LINE_NUMBER_MARGIN: f32 = 40.0;
@@ -86,8 +82,8 @@ impl<'a> EditorContent<'a> {
                             egui::vec2(LINE_NUMBER_MARGIN, 0.0),
                             egui::Sense::hover(),
                         );
-
                         let text_edit = egui::TextEdit::multiline(&mut buffer)
+                            .id(egui::Id::new("editor_text_edit"))
                             .interactive(!doc.is_reference)
                             .font(egui::TextStyle::Monospace)
                             .desired_width(f32::INFINITY)
@@ -99,22 +95,16 @@ impl<'a> EditorContent<'a> {
                                 bottom: 0,
                             })
                             .frame(egui::Frame::NONE);
-
                         let text_output = text_edit.show(ui);
                         let response = text_output.response;
-
                         EditorLogicOps::render_context_menu(ui, &response, action);
                         let galley = text_output.galley;
-
-                        /* WHY: Capture the current cursor range so action handlers can read it. */
                         if let Some(range) = text_output.cursor_range {
                             *cursor_range_out = Some(range);
                         }
-
                         if let Some(cursor_range) = self.pending_cursor {
                             EditorLogicOps::apply_pending_cursor(ui, response.id, cursor_range);
                         }
-
                         if sync_scroll
                             && response.clicked()
                             && let Some(c) = text_output.cursor_range
@@ -122,7 +112,6 @@ impl<'a> EditorContent<'a> {
                             let line = EditorLogicOps::char_index_to_line(&buffer, c.primary.index);
                             scroll.scroll_to_line = Some(line);
                         }
-
                         let current_cursor_y =
                             super::decorations::EditorDecorations::render_cursor_line(
                                 ui,
@@ -136,7 +125,6 @@ impl<'a> EditorContent<'a> {
                                     current_line_bg,
                                 },
                             );
-
                         super::decorations::EditorDecorations::render_hovered_lines(
                             ui,
                             &buffer,
@@ -146,7 +134,6 @@ impl<'a> EditorContent<'a> {
                             &response.rect,
                             hover_line_bg,
                         );
-
                         super::decorations::EditorDecorations::render_search_matches(
                             ui,
                             &galley,
@@ -154,7 +141,6 @@ impl<'a> EditorContent<'a> {
                             self.doc_search_matches,
                             self.doc_search_active_index,
                         );
-
                         const PAD_RIGHT: f32 = 8.0;
                         super::line_numbers::EditorLineNumbers::render(
                             ui,
@@ -171,8 +157,17 @@ impl<'a> EditorContent<'a> {
                             },
                         );
 
-                        if response.changed() {
+                        let text_changed = response.changed();
+                        let should_ingest_clipboard_image =
+                            EditorLogicOps::editor_clipboard_image_paste_requested(
+                                ui,
+                                &response,
+                                text_changed,
+                            );
+                        if text_changed {
                             *action = AppAction::UpdateBuffer(buffer.clone());
+                        } else if !doc.is_reference && should_ingest_clipboard_image {
+                            *action = AppAction::IngestClipboardImage;
                         }
                         EditorLogicOps::handle_scroll_to_line(
                             ui, scroll, &buffer, &response, &galley,

--- a/crates/katana-ui/src/views/panels/editor/utils.rs
+++ b/crates/katana-ui/src/views/panels/editor/utils.rs
@@ -28,31 +28,24 @@ impl super::types::EditorLogicOps {
         line_start: usize,
         line_end: usize,
     ) -> Option<(usize, usize)> {
-        let mut current_line = 0;
-        let mut start_char = None;
-        let mut end_char = None;
+        if line_start > line_end {
+            return None;
+        }
 
+        let start = Self::line_to_char_index(buffer, line_start)?;
+        let mut current_line = 0;
+        let mut end = None;
         for (char_idx, c) in buffer.chars().enumerate() {
-            if current_line == line_start && start_char.is_none() {
-                start_char = Some(char_idx);
-            }
-            if current_line == line_end && end_char.is_none() {
-                end_char = Some(char_idx);
+            if current_line == line_end && c == '\n' {
+                end = Some(char_idx);
+                break;
             }
             if c == '\n' {
                 current_line += 1;
             }
         }
-
-        if start_char.is_some() && end_char.is_none() {
-            end_char = Some(buffer.len());
-        }
-
-        if let (Some(s), Some(e)) = (start_char, end_char) {
-            Some((s, e))
-        } else {
-            None
-        }
+        let end = end.unwrap_or_else(|| buffer.chars().count());
+        Some((start, end))
     }
 
     /* WHY: Extract physical row Y positions for the start of each logical line. */

--- a/crates/katana-ui/src/views/panels/preview/content.rs
+++ b/crates/katana-ui/src/views/panels/preview/content.rs
@@ -70,7 +70,10 @@ impl<'a> PreviewContent<'a> {
 
         let mut scroll_area = egui::ScrollArea::vertical()
             .auto_shrink([false; 2])
-            .id_source("preview_scroll_area");
+            .id_salt((
+                "preview_scroll_area",
+                document.map(|doc| doc.path.as_path()),
+            ));
 
         if let Some(offset) = forced_offset {
             scroll_area = scroll_area.vertical_scroll_offset(offset);

--- a/crates/katana-ui/tests/integration/app/state.rs
+++ b/crates/katana-ui/tests/integration/app/state.rs
@@ -44,6 +44,23 @@ fn active_document_returns_correct_doc_when_set() {
 }
 
 #[test]
+fn markdown_document_defaults_to_code_mode() {
+    let mut state = AppState::new(
+        AiProviderRegistry::new(),
+        PluginRegistry::new(),
+        katana_platform::SettingsService::default(),
+        std::sync::Arc::new(katana_platform::InMemoryCacheService::default()),
+    );
+    state
+        .document
+        .open_documents
+        .push(Document::new("memo.md", "# Memo"));
+    state.document.active_doc_idx = Some(0);
+
+    assert_eq!(state.active_view_mode(), ViewMode::CodeOnly);
+}
+
+#[test]
 fn is_dirty_reflects_active_document_state() {
     /* WHY: Verify that the top-level is_dirty() check correctly reports the dirty status of the currently active document. */
     let mut state = AppState::new(

--- a/crates/katana-ui/tests/integration/editor/toggle_view_modes.rs
+++ b/crates/katana-ui/tests/integration/editor/toggle_view_modes.rs
@@ -23,10 +23,10 @@ fn test_integration_toggle_view_modes() {
         .trigger_action(AppAction::SelectDocument(abs_path));
     harness.step();
 
-    // 1. Initial mode should be PreviewOnly (default)
+    // 1. Editable Markdown documents should open in CodeOnly so authoring controls are visible.
     assert_eq!(
         harness.state_mut().app_state_mut().active_view_mode(),
-        ViewMode::PreviewOnly
+        ViewMode::CodeOnly
     );
 
     // 2. ToggleSplitMode -> Always Split

--- a/crates/katana-ui/tests/integration/toc/panel.rs
+++ b/crates/katana-ui/tests/integration/toc/panel.rs
@@ -1,6 +1,6 @@
 use crate::integration::harness_utils::{fresh_temp_dir, setup_harness, wait_for_workspace_load};
 use egui_kittest::kittest::Queryable;
-use katana_ui::app_state::AppAction;
+use katana_ui::app_state::{AppAction, ViewMode};
 use katana_ui::i18n::I18nOps;
 
 #[test]
@@ -26,6 +26,10 @@ fn test_integration_toc_panel_display() {
         .state_mut()
         .trigger_action(AppAction::SelectDocument(test_file1.clone()));
     harness.step();
+    harness
+        .state_mut()
+        .app_state_mut()
+        .set_active_view_mode(ViewMode::Split);
     harness.step();
 
     /* WHY: Verify the toggle button is present in the rendered UI with the correct label. */

--- a/openspec/changes/v0-22-5-code-input-improvements/.openspec.yaml
+++ b/openspec/changes/v0-22-5-code-input-improvements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/v0-22-5-code-input-improvements/design.md
+++ b/openspec/changes/v0-22-5-code-input-improvements/design.md
@@ -1,0 +1,112 @@
+## Context
+
+The current release branch already contains pieces of v0.22 authoring work: `AppAction::AuthorMarkdown`, `AppAction::IngestImageFile`, `AppAction::IngestClipboardImage`, editor toolbar rendering, command inventory entries, and an image ingest path that writes assets and inserts Markdown image syntax. The redo must make these pieces safe for the actual editor input workflow.
+
+Two implementation details are especially important:
+
+- `ShortcutContextResolver::context_allows` currently allows global shortcuts while the editor context is active. This is useful for some app commands, but unsafe for text-entry combinations that the editor or OS input method owns.
+- Clipboard image ingest currently exists as an explicit command. v0.22.5 requires the normal paste gesture to work for image data without breaking normal text paste.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Protect editor input mode from shortcut collisions with typing, native text editing, IME composition, selection, and normal paste.
+- Keep Markdown source as the only editable document representation.
+- Keep the authoring toolbar visible for editable Markdown documents and actionable without stealing text input.
+- Route image file attach through the command palette.
+- Route clipboard image ingest through normal paste when image data is present, while leaving text paste untouched.
+- Ensure manual upward scrolling to the document top is not overridden by scroll sync, cursor-line handling, or toolbar layout.
+
+**Non-Goals:**
+
+- Introducing a WYSIWYG editor or a second document model.
+- Adding non-image asset ingest, drag-and-drop ingest, or media-library management.
+- Reworking all shortcut customization UX beyond the conflict checks required for editor input safety.
+- Changing the existing document-relative image save policy unless needed to fix paste/attach regressions.
+
+## Decisions
+
+### 1. Treat editor input as a protected shortcut context
+
+When the editor text widget has focus, protected text-entry shortcuts MUST pass through to the editor/OS instead of being consumed by app-level command dispatch. The protected set includes ordinary text input, IME composition, cursor movement, selection movement, copy, cut, undo, redo, select all, text paste, newline, indentation, backspace, delete, and platform equivalents.
+
+Implementation direction:
+
+- Keep `ShortcutContext::Editor`, but add an explicit protected-shortcut check before `ctx.input_mut(|i| i.consume_shortcut(...))` in `shell_ui_shortcuts.rs`.
+- Do not rely only on command context metadata. Global commands must not fire over protected editor input keys.
+- Remove or change default editor command shortcuts that collide with expected input behavior. The command palette and toolbar remain available for those commands.
+- Add unit tests proving that protected combinations are not consumed as app commands in editor context, and that non-conflicting editor commands can still run.
+
+Alternative considered: removing all global shortcuts while editing. This would be safe but too broad; non-conflicting global commands can remain useful if they do not interfere with text entry.
+
+### 2. Normal paste handles images, explicit command handles attach
+
+Normal paste must continue to be a text-edit operation when clipboard text exists. Clipboard image ingest should run from the same paste path only when image data is available for the active editable Markdown document and the paste would otherwise not insert text.
+
+Implementation direction:
+
+- Keep `AppAction::IngestImageFile` as a command inventory action so it appears in the command palette.
+- Do not make `primary+V` a normal command inventory shortcut for image ingest. That would steal text paste from the editor.
+- Add a paste-event bridge in the editor input path that detects image clipboard data and dispatches image ingest only for image paste cases.
+- Keep the explicit `IngestClipboardImage` action as a fallback command if useful, but the release acceptance path is normal paste.
+- Add tests for text clipboard pass-through and image clipboard ingest.
+
+Alternative considered: using only `primary+shift+V` for image paste. This does not satisfy the release feedback because users expect normal paste to work for clipboard images.
+
+### 3. Toolbar rendering is part of editor authoring, not release chrome
+
+The input support toolbar must render with the editor panel for editable Markdown documents. It should be hidden for read-only/reference/virtual documents and must not depend on a stale cursor range from the previous frame to appear.
+
+Implementation direction:
+
+- Keep toolbar rendering near `EditorContent::show`, before the `TextEdit` body.
+- Ensure toolbar layout uses stable height and does not create an expanding top panel.
+- Toolbar buttons dispatch authoring actions without taking ownership of normal text input.
+- Add a UI or integration check that opens an editable Markdown file and verifies the toolbar controls are visible.
+
+### 4. Scroll recovery must be manually controllable
+
+Manual upward scrolling should remain possible even after scroll sync, cursor-line highlighting, toolbar actions, or `scroll_to_line` navigation. If the user scrolls upward, stale programmatic scroll requests must not repeatedly pull the editor back down.
+
+Implementation direction:
+
+- Audit `ScrollState::scroll_to_line`, `last_scroll_to_line`, `ScrollSource`, and editor/preview echo handling.
+- Clear one-shot scroll requests after they are consumed.
+- Ensure manual editor scroll updates set the source only when the movement exceeds the dead zone and does not fight a user's upward wheel/trackpad input.
+- Add tests around `handle_scroll_to_line` and `update_scroll_sync` for top recovery.
+
+### 5. Verification must match the release feedback
+
+The implementation is complete only when the following user review cases are demonstrated:
+
+- Markdown text can be typed into an editable document.
+- The authoring toolbar is visible and its buttons can trigger Markdown insertion.
+- The editor can scroll back to the document top after being scrolled down.
+- Command palette search can find and run image file attach.
+- Pasting a clipboard image with normal paste saves an asset and inserts Markdown image syntax.
+- Pasting text with normal paste still inserts text.
+
+## Risks / Trade-offs
+
+- **Risk: app shortcuts become unavailable while editing.**
+  Mitigation: suppress only protected text-entry conflicts and keep toolbar/palette routes for authoring commands.
+- **Risk: clipboard APIs differ by platform.**
+  Mitigation: keep image extraction behind the existing ingest action/path and report unsupported clipboard image data without changing text paste behavior.
+- **Risk: toolbar focus steals the editor context.**
+  Mitigation: make toolbar actions explicit button clicks and avoid keyboard handling in the toolbar itself.
+- **Risk: scroll sync reintroduces downward pull after top recovery.**
+  Mitigation: test one-shot scroll clearing and editor/preview source transitions after manual upward scroll.
+
+## Migration Plan
+
+1. Add regression tests or reproducible checks for the five release feedback cases before changing behavior.
+2. Implement protected editor shortcut handling and remove conflicting default bindings.
+3. Restore/verify editor toolbar rendering and Markdown authoring action dispatch.
+4. Add command palette coverage for image attach and normal paste coverage for clipboard images.
+5. Fix scroll recovery and run focused tests before the full `make check` gate.
+
+## Open Questions
+
+- Whether clipboard image paste should take priority when the clipboard contains both text and image data. The default implementation should prefer text paste unless product review explicitly wants image priority.
+- Whether to keep `primary+shift+V` as a secondary image paste command after normal paste is implemented.

--- a/openspec/changes/v0-22-5-code-input-improvements/proposal.md
+++ b/openspec/changes/v0-22-5-code-input-improvements/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+v0.22.5 is a redo of the code input improvements work for the `release/v0.22.5` integration branch. The previous archived change still contains stale version labels and a dummy task, while the release workflow needs an active OpenSpec change that captures the latest user review feedback.
+
+The release priority is not to expand authoring scope. It is to fix input regressions first: Markdown must be typeable, input support UI must be visible, scrolling must remain recoverable upward, and image attach/paste paths must be discoverable and usable without fighting editor input behavior.
+
+## What Changes
+
+- Treat editor input mode as a protected text-entry context: application shortcuts that conflict with native editor/input behavior MUST be disabled while the text editor is focused.
+- Restore and verify the editor authoring support toolbar for editable Markdown documents.
+- Keep ordinary Markdown typing, IME composition, selection, undo/redo, and normal paste behavior intact.
+- Make clipboard images work through the normal paste flow when the clipboard contains image data.
+- Add a command palette route for attaching an image file to the active Markdown document.
+- Preserve the existing image ingest contract: save images under the configured document-relative asset directory and insert a relative Markdown image reference.
+- Fix scroll regressions so the editor can be scrolled back to the top after typing, using the toolbar, or synchronizing with preview.
+
+## Capabilities
+
+### New Capabilities
+
+- `markdown-asset-ingest`: Image file attach, clipboard image paste, document-relative asset saving, and Markdown image reference insertion.
+
+### Modified Capabilities
+
+- `markdown-authoring`: Editor input safety, source-first authoring controls, toolbar visibility, and editor scroll recovery.
+
+## Impact
+
+- Primary UI/action areas: `crates/katana-ui/src/views/panels/editor/ui.rs`, `crates/katana-ui/src/views/panels/editor/toolbar.rs`, `crates/katana-ui/src/views/panels/editor/logic.rs`, `crates/katana-ui/src/app/action/process_authoring.rs`, and `crates/katana-ui/src/app/action/image_ingest.rs`.
+- Shortcut and command routing areas: `crates/katana-ui/src/state/shortcut_context.rs`, `crates/katana-ui/src/shell_ui/shell_ui_shortcuts.rs`, `crates/katana-ui/src/state/command_inventory/edit_commands.rs`, and command palette providers/results.
+- Verification areas: focused unit tests for shortcut context and image ingest, editor logic tests for scroll recovery, and UI/integration coverage proving Markdown input, toolbar visibility, command palette image attach, and normal clipboard image paste.

--- a/openspec/changes/v0-22-5-code-input-improvements/specs/markdown-asset-ingest/spec.md
+++ b/openspec/changes/v0-22-5-code-input-improvements/specs/markdown-asset-ingest/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: User can attach an image file from the command palette
+
+The system SHALL expose image file attach as a command palette action when an editable Markdown document is active.
+
+#### Scenario: Image attach command is discoverable
+
+- **WHEN** the user opens the command palette while an editable Markdown document is active
+- **THEN** the system shows an image attach command when the query matches image attach wording
+- **THEN** selecting that result starts the image file attach flow
+
+#### Scenario: Image attach command is unavailable without editable Markdown
+
+- **WHEN** no editable Markdown document is active
+- **THEN** the system MUST NOT present image attach as an executable command palette action
+
+### Requirement: User can paste clipboard images with normal paste
+
+The system SHALL support normal paste for clipboard image data in an editable Markdown document.
+
+#### Scenario: Clipboard image normal paste
+
+- **WHEN** the user focuses an editable Markdown document and the clipboard contains image data
+- **THEN** the user can invoke the platform normal paste gesture
+- **THEN** the system saves the image through the configured image ingest path
+- **THEN** the system inserts a relative Markdown image reference at the editor insertion point
+
+#### Scenario: Text paste remains normal text paste
+
+- **WHEN** the user focuses an editable Markdown document and the clipboard contains text
+- **THEN** the platform normal paste gesture inserts text into the Markdown buffer
+- **THEN** the system MUST NOT replace the text paste with image ingest
+
+### Requirement: Image ingest uses document-relative asset output
+
+The system SHALL save pasted or attached images using the configured document-relative image save directory and insert a Markdown image reference that resolves from the active document.
+
+#### Scenario: Asset directory is created and referenced
+
+- **WHEN** the user attaches or pastes an image into an editable saved Markdown document
+- **THEN** the system resolves the output directory relative to the active Markdown document
+- **THEN** the system creates the directory when the image ingest settings allow it
+- **THEN** the system inserts Markdown image syntax pointing to the saved asset with a relative path
+
+#### Scenario: Unsaved or non-file document cannot ingest image
+
+- **WHEN** the active document has no file path that can anchor a relative asset directory
+- **THEN** the system MUST NOT write image bytes to an arbitrary location
+- **THEN** the system reports or exposes an unavailable state for image ingest

--- a/openspec/changes/v0-22-5-code-input-improvements/specs/markdown-authoring/spec.md
+++ b/openspec/changes/v0-22-5-code-input-improvements/specs/markdown-authoring/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Editor input mode protects native text entry
+
+The system MUST NOT consume editor-owned or OS-owned text-entry shortcuts as application commands while an editable Markdown editor has keyboard focus.
+
+#### Scenario: Markdown text input is preserved
+
+- **WHEN** the user focuses an editable Markdown document and types Markdown source text
+- **THEN** the system updates the in-memory document buffer with the typed Markdown
+- **THEN** the system does not trigger unrelated application commands from the typed input
+
+#### Scenario: Protected editor shortcut is not consumed by app command dispatch
+
+- **WHEN** the editor has keyboard focus and the user presses a protected text-entry shortcut such as paste, copy, cut, undo, redo, select all, cursor movement, selection movement, newline, indentation, backspace, or delete
+- **THEN** the system MUST allow the editor or operating system input method to handle that shortcut
+- **THEN** the system MUST NOT dispatch a global or editor authoring command for that shortcut in the same frame
+
+#### Scenario: Non-conflicting editor command remains available
+
+- **WHEN** the editor has keyboard focus and the user invokes an editor command that does not conflict with protected text entry
+- **THEN** the system MAY dispatch that editor command
+- **THEN** the command MUST preserve the Markdown source-first editing contract
+
+### Requirement: Editable Markdown documents show authoring support UI
+
+The system SHALL show the Markdown input support toolbar for editable Markdown documents without requiring a stale cursor selection state.
+
+#### Scenario: Toolbar appears for editable Markdown
+
+- **WHEN** the user opens an editable Markdown document in editor mode
+- **THEN** the system shows the authoring toolbar in the editor panel
+- **THEN** the toolbar includes controls for common Markdown insertion actions such as inline formatting, headings, lists, quotes, and code blocks
+
+#### Scenario: Toolbar stays out of read-only documents
+
+- **WHEN** the active document is read-only, reference-only, or a virtual built-in document
+- **THEN** the system MUST NOT show mutating authoring controls for that document
+
+### Requirement: Authoring controls preserve Markdown source editing
+
+The system SHALL apply toolbar and command palette authoring actions by editing Markdown source text in the active buffer.
+
+#### Scenario: Toolbar action inserts Markdown syntax
+
+- **WHEN** the user triggers a toolbar authoring action in an editable Markdown document
+- **THEN** the system updates the active Markdown buffer with the corresponding Markdown syntax
+- **THEN** the document dirty state and preview refresh behavior follow the same path as ordinary typing
+
+### Requirement: Editor scroll can return to the document start
+
+The system SHALL allow the user to manually scroll an editable Markdown editor back to the top after typing, toolbar actions, search navigation, or preview scroll sync.
+
+#### Scenario: User scrolls back to top after editing
+
+- **WHEN** the user scrolls down in a long editable Markdown document and then scrolls upward to the start of the document
+- **THEN** the system displays the beginning of the document again
+- **THEN** stale cursor, search, or scroll-sync state MUST NOT force the editor back down
+
+#### Scenario: Scroll sync does not fight manual upward scroll
+
+- **WHEN** split view scroll sync is enabled and the user manually scrolls the editor upward
+- **THEN** the editor scroll position follows the user's input
+- **THEN** preview synchronization MUST NOT prevent the editor from reaching the top

--- a/openspec/changes/v0-22-5-code-input-improvements/tasks.md
+++ b/openspec/changes/v0-22-5-code-input-improvements/tasks.md
@@ -1,0 +1,117 @@
+## Definition of Ready (DoR)
+
+- [x] `proposal.md`、`design.md`、`specs/markdown-authoring/spec.md`、`specs/markdown-asset-ingest/spec.md` が active change として揃っていること
+- [x] 対象バージョンが `0.22.5`、change-id が `v0-22-5-code-input-improvements`、作業ベースが `release/v0.22.5` であることを確認する
+- [x] 既存 archive `openspec/changes/archive/2026-04-24-v0-22-5-code-input-improvements` は参照のみとし、編集・移動しないことを確認する
+- [x] ユーザーFBの優先順位を確認する: Markdown 入力、toolbar 表示、上方向 scroll 復帰をデグレード優先修正として扱う
+
+## Branch Rule
+
+本タスクでは、以下のブランチ運用を適用します：
+
+- **標準（Base）ブランチ**: `release/v0.22.5`
+- **作業ブランチ**: `feature/v0.22.5-task-x` (x はタスク番号)
+
+実装完了後は `/openspec-delivery` を使用して Base ブランチへ PR を作成・マージしてください。
+
+> Implementation note: 以前の v0.22.5 worktree は破棄して作り直したため、タスク 1-5 は `feature/v0.22.5-task1-code-input-recovery` でまとめて recovery 実装する。
+
+---
+
+## 1. User Review Feedback Regression Baseline
+
+- [x] 1.1 `release/v0.22.5` 上で、Markdown が入力できること、入力サポート UI/toolbar が表示されること、editor を上に戻せることを手動または既存 harness で再現確認する
+- [x] 1.2 editor 入力中に競合しうる shortcut を棚卸しする: normal paste、copy/cut、undo/redo、select all、IME composition、cursor/selection movement、newline、indent、delete/backspace
+- [x] 1.3 画像添付の既存導線を確認し、command palette から image attach を検索・実行できるかを記録する
+- [x] 1.4 clipboard に画像だけがある場合と text がある場合の normal paste 挙動を分けて記録する
+- [x] 1.5 上記 4 つのユーザーFBを回帰テストまたは明示的な検証手順に落とし込む
+
+### Definition of Done (DoD)
+
+- [x] v0.22.5 で修正すべき入力回帰が、再現条件と期待結果つきで整理されていること
+- [x] 以降のタスクが参照できる検証項目として、ユーザーFB 1-4 がすべて追跡可能になっていること
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 2. Editor Input Shortcut Conflict Isolation
+
+### Definition of Ready (DoR)
+
+- [x] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
+- [x] Base branch is synced, and a new branch is explicitly created for this task.
+
+- [x] 2.1 `crates/katana-ui/src/state/shortcut_context.rs` と `crates/katana-ui/src/shell_ui/shell_ui_shortcuts.rs` を修正し、editor focus 中の protected text-entry shortcut を app command dispatch が consume しないようにする
+- [x] 2.2 `crates/katana-ui/src/state/command_inventory/edit_commands.rs` の default shortcut を見直し、editor/native input と競合する authoring command は default shortcut を外すか非競合の導線へ移す
+- [x] 2.3 editor focus 中に Global shortcut が protected input を横取りしない unit test を追加する
+- [x] 2.4 non-conflicting editor command は toolbar または command palette から実行できることを確認する
+
+### Definition of Done (DoD)
+
+- [x] editor 入力モードで、入力機能と競合する shortcut が無効化されていること
+- [x] Markdown typing、IME composition、selection movement、normal paste、undo/redo が app command と競合しないこと
+- [x] shortcut 関連 unit test が pass すること
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 3. Markdown Input, Toolbar, and Scroll Regression Fixes
+
+### Definition of Ready (DoR)
+
+- [x] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
+- [x] Base branch is synced, and a new branch is explicitly created for this task.
+
+- [x] 3.1 `crates/katana-ui/src/views/panels/editor/ui.rs` の `TextEdit` が editable Markdown で入力可能な状態を維持していることを確認し、typing が `AppAction::UpdateBuffer` へ到達するよう修正する
+- [x] 3.2 `crates/katana-ui/src/views/panels/editor/toolbar.rs` の authoring toolbar が editable Markdown document で常に表示され、read-only/reference/virtual document では mutating controls を出さないようにする
+- [x] 3.3 toolbar button からの authoring action が Markdown source buffer、dirty state、preview refresh と同じ更新経路に乗ることを確認する
+- [x] 3.4 `crates/katana-ui/src/views/panels/editor/logic.rs` と `crates/katana-ui/src/state/scroll.rs` 周辺を修正し、scroll down 後に上方向へ戻せること、scroll sync が manual upward scroll を妨げないことを保証する
+- [x] 3.5 UI スナップショットまたは integration harness で、Markdown 入力、toolbar 表示、上方向 scroll 復帰をユーザーに提示できる形で確認する
+- [x] 3.6 ユーザーからのフィードバックに基づく UI の微調整および改善実装
+
+### Definition of Done (DoD)
+
+- [x] Markdown が通常入力できること
+- [x] 入力サポート UI/toolbar が editable Markdown document で表示されること
+- [x] 長い Markdown document で下へ scroll した後、先頭まで上に戻せること
+- [x] editor/toolbar/scroll 関連の focused tests が pass すること
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 4. Image Attach Command Palette Route and Normal Paste
+
+### Definition of Ready (DoR)
+
+- [x] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
+- [x] Base branch is synced, and a new branch is explicitly created for this task.
+
+- [x] 4.1 `AppAction::IngestImageFile` を shared command inventory 経由で command palette result として検索・実行できることを確認し、不足があれば provider/result execution を修正する
+- [x] 4.2 command palette で「Attach Image File」「画像添付」相当の query から画像添付 flow に到達できる integration test または UI 検証を追加する
+- [x] 4.3 normal paste gesture で clipboard image を検出し、`AppAction::IngestClipboardImage` または同等の ingest path に接続する
+- [x] 4.4 clipboard text がある場合は normal paste が text paste として動作し、image ingest が横取りしないことを保証する
+- [x] 4.5 画像保存先、directory auto-create、Markdown image reference 挿入が existing ingest settings と一致することを unit test で確認する
+
+### Definition of Done (DoD)
+
+- [x] 画像添付を command palette から開始できること
+- [x] クリップボード画像を通常 paste で Markdown document に挿入できること
+- [x] text clipboard の通常 paste が壊れていないこと
+- [x] image ingest 関連の focused tests が pass すること
+- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+
+---
+
+## 5. Final Verification and Release Readiness
+
+### Definition of Ready (DoR)
+
+- [x] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
+- [x] Base branch is synced, and a new branch is explicitly created for this task.
+
+- [x] 5.1 `docs/coding-rules.ja.md` と `.agents/skills/self-review/SKILL.md` に基づく自己レビューを実施する
+- [x] 5.2 ユーザーFB 4 件を release checklist として再検証する: shortcut 無効化、command palette 画像添付、normal paste 画像、Markdown 入力/toolbar/scroll 復帰
+- [x] 5.3 `cargo test -p katana-ui` など focused tests を実行し、editor shortcut、toolbar、scroll、image ingest の対象テストが pass することを確認する
+- [x] 5.4 `make check` が exit code 0 で通過することを確認する
+- [x] 5.5 `release/v0.22.5` 上で impl-release workflow がこの active change を参照できることを確認する
+- [ ] 5.6 Release Readiness CI と GitHub Release 完了後、この change を `/opsx-archive` で archive する


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

v0.22.5 のコード入力回帰を復旧し、追加FBとして OpenSpec に editor shortcut 保護、画像添付 command palette、clipboard 画像 paste を取り込みました。

## 対応内容

- Markdown document の初期表示を editable では CodeOnly にし、toolbar と TextEdit 入力を復旧
- editor focus 中は native text entry と競合する protected shortcut を app command が consume しないよう整理
- command palette の通常検索から image file attach / clipboard image ingest を発見可能に修正
- normal paste で text paste を優先しつつ、画像 clipboard だけの paste を image ingest に接続
- document 切替時の scroll state と editor/preview scroll id を分離して上方向 scroll 回帰を修正
- `openspec/changes/v0-22-5-code-input-improvements` を active change として追加

## 動作確認

- `openspec validate v0-22-5-code-input-improvements`
- `git diff --check` / `git diff --cached --check`
- `cargo test -p katana-ui --lib shell_ui::shortcut_keys::tests -- --nocapture`
- `cargo test -p katana-ui --lib views::modals::command_palette::tests -- --nocapture`
- `cargo test -p katana-ui --lib views::panels::editor::logic::tests -- --nocapture`
- `cargo test -p katana-ui --test ui_integration_parallel app_state::markdown_document_defaults_to_code_mode -- --nocapture`
- `cargo test -p katana-ui --test ui_integration_parallel command_palette::test_app_command_provider -- --nocapture`
- `cargo test -p katana-ui --test integration_tests integration::toc::panel::test_integration_toc_panel_display -- --nocapture`
- `make check`
