### PR TITLE
fix: Lintの有効設定解決を整理

### DIFF
--- a/crates/katana-ui/src/linter_bridge.rs
+++ b/crates/katana-ui/src/linter_bridge.rs
@@ -22,7 +22,13 @@ impl MarkdownLinterBridgeOps {
             );
         let mut severity_map = Self::severity_map(&options);
         for (rule_id, severity) in &linter_settings.rule_severity {
-            severity_map.insert(rule_id.clone(), Self::configured_severity(severity));
+            if options
+                .rules
+                .get(rule_id)
+                .is_none_or(|rule_config| rule_config.enabled)
+            {
+                severity_map.insert(rule_id.clone(), Self::configured_severity(severity));
+            }
         }
 
         MarkdownLinterOps::evaluate_all(
@@ -184,6 +190,36 @@ mod tests {
 
         assert_eq!(diagnostic.severity, DiagnosticSeverity::Error);
         assert!(!MarkdownLinterBridgeOps::diagnostic_message(diagnostic).is_empty());
+    }
+
+    #[test]
+    fn evaluate_document_does_not_reenable_markdownlint_disabled_rule() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".markdownlint.json"),
+            r#"{"default": false, "MD001": false}"#,
+        )
+        .unwrap();
+        let mut state = make_workspace_state(&dir);
+        state
+            .config
+            .settings
+            .settings_mut()
+            .linter
+            .rule_severity
+            .insert("MD001".to_string(), RuleSeverity::Warning);
+
+        let diagnostics = MarkdownLinterBridgeOps::evaluate_document(
+            &state,
+            &dir.path().join("doc.md"),
+            "# Title\n### Skipped\n",
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.rule_id != "MD001")
+        );
     }
 
     #[test]

--- a/crates/katana-ui/src/linter_config_bridge.rs
+++ b/crates/katana-ui/src/linter_config_bridge.rs
@@ -10,21 +10,9 @@ impl MarkdownLinterConfigOps {
             .settings()
             .linter
             .use_workspace_local_config;
-
-        let global_config_dir = dirs::config_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("KatanA");
-        let global_json_path = global_config_dir.join(".markdownlint.json");
-        let workspace_json_path = state
-            .workspace
-            .data
-            .as_ref()
-            .map(|workspace| workspace.root.join(".markdownlint.json"));
-        let workspace_jsonc_path = state
-            .workspace
-            .data
-            .as_ref()
-            .map(|workspace| workspace.root.join(".markdownlint.jsonc"));
+        let global_json_path = Self::global_config_path();
+        let workspace_json_path = Self::workspace_json_path(state);
+        let workspace_jsonc_path = Self::workspace_jsonc_path(state);
 
         if use_workspace {
             if let Some(path) = workspace_json_path.as_ref()
@@ -43,6 +31,20 @@ impl MarkdownLinterConfigOps {
         }
     }
 
+    pub(crate) fn effective_config_path(state: &crate::app_state::AppState) -> Option<PathBuf> {
+        Self::select_effective_config_path(
+            state
+                .config
+                .settings
+                .settings()
+                .linter
+                .use_workspace_local_config,
+            Self::workspace_json_path(state).as_deref(),
+            Self::workspace_jsonc_path(state).as_deref(),
+            &Self::global_config_path(),
+        )
+    }
+
     #[cfg(test)]
     pub(crate) fn load_options(
         state: &crate::app_state::AppState,
@@ -55,64 +57,64 @@ impl MarkdownLinterConfigOps {
 
     pub(crate) fn load_options_for_path(
         state: &crate::app_state::AppState,
-        path: &Path,
+        _path: &Path,
     ) -> katana_markdown_linter::LintOptions {
-        let target_path = Self::effective_config_path(state, path);
-        katana_markdown_linter::MarkdownLintConfig::load(target_path.as_path())
-            .unwrap_or_default()
-            .to_lint_options()
+        Self::load_effective_config(state).to_lint_options()
     }
 
-    fn effective_config_path(state: &crate::app_state::AppState, path: &Path) -> PathBuf {
-        if state
-            .config
-            .settings
-            .settings()
-            .linter
-            .use_workspace_local_config
-        {
-            return Self::target_config_path(state);
+    pub(crate) fn load_effective_config(
+        state: &crate::app_state::AppState,
+    ) -> katana_markdown_linter::MarkdownLintConfig {
+        Self::effective_config_path(state)
+            .and_then(|path| katana_markdown_linter::MarkdownLintConfig::load(&path).ok())
+            .unwrap_or_default()
+    }
+
+    fn select_effective_config_path(
+        use_workspace: bool,
+        workspace_json_path: Option<&Path>,
+        workspace_jsonc_path: Option<&Path>,
+        global_json_path: &Path,
+    ) -> Option<PathBuf> {
+        if use_workspace {
+            if let Some(path) = workspace_json_path
+                && path.exists()
+            {
+                return Some(path.to_path_buf());
+            }
+            if let Some(path) = workspace_jsonc_path
+                && path.exists()
+            {
+                return Some(path.to_path_buf());
+            }
         }
 
-        Self::discover_config_path(state, path).unwrap_or_else(|| Self::target_config_path(state))
+        global_json_path
+            .exists()
+            .then(|| global_json_path.to_path_buf())
     }
 
-    fn discover_config_path(state: &crate::app_state::AppState, path: &Path) -> Option<PathBuf> {
-        let workspace_root = state
+    fn global_config_path() -> PathBuf {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("KatanA")
+            .join(".markdownlint.json")
+    }
+
+    fn workspace_json_path(state: &crate::app_state::AppState) -> Option<PathBuf> {
+        state
             .workspace
             .data
             .as_ref()
-            .map(|workspace| workspace.root.as_path());
-
-        let mut current = path.parent()?;
-        loop {
-            if workspace_root.is_some_and(|root| !current.starts_with(root)) {
-                break;
-            }
-            if let Some(config_path) = Self::config_file_in_dir(current) {
-                return Some(config_path);
-            }
-            if workspace_root.is_some_and(|root| current == root) {
-                break;
-            }
-            current = current.parent()?;
-        }
-
-        None
+            .map(|workspace| workspace.root.join(".markdownlint.json"))
     }
 
-    fn config_file_in_dir(dir: &Path) -> Option<PathBuf> {
-        let json_path = dir.join(".markdownlint.json");
-        if json_path.exists() {
-            return Some(json_path);
-        }
-
-        let jsonc_path = dir.join(".markdownlint.jsonc");
-        if jsonc_path.exists() {
-            return Some(jsonc_path);
-        }
-
-        None
+    fn workspace_jsonc_path(state: &crate::app_state::AppState) -> Option<PathBuf> {
+        state
+            .workspace
+            .data
+            .as_ref()
+            .map(|workspace| workspace.root.join(".markdownlint.jsonc"))
     }
 }
 
@@ -197,74 +199,106 @@ mod tests {
     }
 
     #[test]
-    fn load_options_for_path_discovers_workspace_config_by_default() {
+    fn effective_config_path_ignores_workspace_config_when_disabled() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join(".markdownlint.json"),
-            r#"{"default": false}"#,
-        )
-        .unwrap();
-        let nested = dir.path().join("docs");
-        std::fs::create_dir_all(&nested).unwrap();
-        let mut state = make_state();
-        state.workspace.data = Some(Workspace::new(dir.path(), Vec::new()));
+        let workspace_config = dir.path().join(".markdownlint.json");
+        let global_config = dir.path().join("global.json");
+        std::fs::write(&workspace_config, r#"{"default": false}"#).unwrap();
+        std::fs::write(&global_config, r#"{"default": true}"#).unwrap();
 
-        let options =
-            MarkdownLinterConfigOps::load_options_for_path(&state, &nested.join("doc.md"));
+        let selected = MarkdownLinterConfigOps::select_effective_config_path(
+            false,
+            Some(&workspace_config),
+            None,
+            &global_config,
+        );
 
-        assert!(options.rules.values().all(|rule| !rule.enabled));
+        assert_eq!(selected, Some(global_config));
     }
 
     #[test]
-    fn load_options_for_path_discovers_jsonc_config_by_default() {
+    fn effective_config_path_prefers_workspace_json_when_enabled() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join(".markdownlint.jsonc"),
-            "{\n  // keep only MD001 enabled\n  \"default\": false,\n  \"MD001\": true,\n}\n",
-        )
-        .unwrap();
-        let mut state = make_state();
-        state.workspace.data = Some(Workspace::new(dir.path(), Vec::new()));
+        let workspace_config = dir.path().join(".markdownlint.json");
+        let global_config = dir.path().join("global.json");
+        std::fs::write(&workspace_config, r#"{"default": false}"#).unwrap();
+        std::fs::write(&global_config, r#"{"default": true}"#).unwrap();
 
-        let options =
-            MarkdownLinterConfigOps::load_options_for_path(&state, &dir.path().join("doc.md"));
+        let selected = MarkdownLinterConfigOps::select_effective_config_path(
+            true,
+            Some(&workspace_config),
+            None,
+            &global_config,
+        );
 
-        assert!(options.rules.get("MD001").unwrap().enabled);
+        assert_eq!(selected, Some(workspace_config));
+    }
+
+    #[test]
+    fn effective_config_path_prefers_workspace_jsonc_when_json_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_json = dir.path().join(".markdownlint.json");
+        let workspace_jsonc = dir.path().join(".markdownlint.jsonc");
+        let global_config = dir.path().join("global.json");
+        std::fs::write(&workspace_jsonc, r#"{"default": false}"#).unwrap();
+        std::fs::write(&global_config, r#"{"default": true}"#).unwrap();
+
+        let selected = MarkdownLinterConfigOps::select_effective_config_path(
+            true,
+            Some(&workspace_json),
+            Some(&workspace_jsonc),
+            &global_config,
+        );
+
+        assert_eq!(selected, Some(workspace_jsonc));
+    }
+
+    #[test]
+    fn effective_config_path_falls_back_to_global_then_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_config = dir.path().join(".markdownlint.json");
+        let global_config = dir.path().join("global.json");
+
+        assert_eq!(
+            MarkdownLinterConfigOps::select_effective_config_path(
+                true,
+                Some(&workspace_config),
+                None,
+                &global_config,
+            ),
+            None
+        );
+
+        std::fs::write(&global_config, r#"{"default": false}"#).unwrap();
+        assert_eq!(
+            MarkdownLinterConfigOps::select_effective_config_path(
+                true,
+                Some(&workspace_config),
+                None,
+                &global_config,
+            ),
+            Some(global_config)
+        );
+    }
+
+    #[test]
+    fn katana_namespace_is_not_markdownlint_compatible() {
+        let config = katana_markdown_linter::MarkdownLintConfig {
+            raw: serde_json::json!({
+                "katana": {
+                    "rule_severity": {
+                        "MD013": "ignore"
+                    }
+                }
+            }),
+        };
+
+        let errors = config.validate_cached_rules();
+
         assert!(
-            options
-                .rules
+            errors
                 .iter()
-                .filter(|(rule_id, _)| rule_id.as_str() != "MD001")
-                .all(|(_, rule)| !rule.enabled)
+                .any(|error| error.kind_code() == "unknown_rule")
         );
-    }
-
-    #[test]
-    fn discover_config_path_stops_at_workspace_root_without_config() {
-        let dir = tempfile::tempdir().unwrap();
-        let nested = dir.path().join("docs");
-        std::fs::create_dir_all(&nested).unwrap();
-        let mut state = make_state();
-        state.workspace.data = Some(Workspace::new(dir.path(), Vec::new()));
-
-        let config_path =
-            MarkdownLinterConfigOps::discover_config_path(&state, &nested.join("doc.md"));
-
-        assert!(config_path.is_none());
-    }
-
-    #[test]
-    fn discover_config_path_does_not_walk_outside_workspace() {
-        let workspace_dir = tempfile::tempdir().unwrap();
-        let outside_dir = tempfile::tempdir().unwrap();
-        let mut state = make_state();
-        state.workspace.data = Some(Workspace::new(workspace_dir.path(), Vec::new()));
-
-        let config_path = MarkdownLinterConfigOps::discover_config_path(
-            &state,
-            &outside_dir.path().join("doc.md"),
-        );
-
-        assert!(config_path.is_none());
     }
 }

--- a/crates/katana-ui/src/linter_options_bridge.rs
+++ b/crates/katana-ui/src/linter_options_bridge.rs
@@ -20,8 +20,10 @@ impl MarkdownLinterOptionsBridgeOps {
 
     fn apply_katana_settings(options: &mut LintOptions, settings: &LinterSettings) {
         for (rule_id, severity) in &settings.rule_severity {
-            let rule_config = options.rules.entry(rule_id.clone()).or_default();
-            rule_config.enabled = !matches!(severity, RuleSeverity::Ignore);
+            if matches!(severity, RuleSeverity::Ignore) {
+                let rule_config = options.rules.entry(rule_id.clone()).or_default();
+                rule_config.enabled = false;
+            }
         }
     }
 }
@@ -72,7 +74,7 @@ mod tests {
     }
 
     #[test]
-    fn katana_warning_enables_rule_in_effective_options() {
+    fn katana_warning_does_not_reenable_disabled_markdownlint_rule() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join(".markdownlint.json"),
@@ -93,6 +95,62 @@ mod tests {
             &dir.path().join("doc.md"),
         );
 
-        assert!(options.rules.get("MD001").unwrap().enabled);
+        assert!(!options.rules.get("MD001").unwrap().enabled);
+    }
+
+    #[test]
+    fn katana_ignore_keeps_rule_properties_for_restore() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".markdownlint.json"),
+            r#"{"MD013": {"enabled": true, "line_length": 80}}"#,
+        )
+        .unwrap();
+        let mut state = make_state(&dir);
+        state
+            .config
+            .settings
+            .settings_mut()
+            .linter
+            .rule_severity
+            .insert("MD013".to_string(), RuleSeverity::Ignore);
+
+        let ignored_options = MarkdownLinterOptionsBridgeOps::load_effective_options(
+            &state,
+            &dir.path().join("doc.md"),
+        );
+        assert!(!ignored_options.rules.get("MD013").unwrap().enabled);
+        assert_eq!(
+            ignored_options
+                .rules
+                .get("MD013")
+                .unwrap()
+                .properties
+                .get("line_length"),
+            Some(&"80".to_string())
+        );
+
+        state
+            .config
+            .settings
+            .settings_mut()
+            .linter
+            .rule_severity
+            .insert("MD013".to_string(), RuleSeverity::Warning);
+        let restored_options = MarkdownLinterOptionsBridgeOps::load_effective_options(
+            &state,
+            &dir.path().join("doc.md"),
+        );
+
+        assert!(restored_options.rules.get("MD013").unwrap().enabled);
+        assert_eq!(
+            restored_options
+                .rules
+                .get("MD013")
+                .unwrap()
+                .properties
+                .get("line_length"),
+            Some(&"80".to_string())
+        );
     }
 }

--- a/crates/katana-ui/src/settings/tabs/linter/workspace.rs
+++ b/crates/katana-ui/src/settings/tabs/linter/workspace.rs
@@ -41,23 +41,10 @@ impl WorkspaceSettingsOps {
                         )
                         .changed()
                     {
-                        state
-                            .config
-                            .settings
-                            .settings_mut()
-                            .linter
-                            .use_workspace_local_config = use_workspace;
-                        let _ = state.config.try_save_settings();
-
-                        let target_path =
-                            crate::linter_config_bridge::MarkdownLinterConfigOps::target_config_path(
-                                state,
-                            );
-
-                        /* WHY: If switching and the target file exists, automatically open the advanced settings */
-                        if target_path.exists() {
-                            *is_advanced_open = true;
-                        }
+                        Self::save_workspace_config_toggle(state, use_workspace);
+                        ui.data_mut(|data| {
+                            data.insert_temp(egui::Id::new("katana_pending_linter_update"), true);
+                        });
                     }
                     ui.add_space(SETTINGS_TOGGLE_SPACING);
                 }
@@ -70,8 +57,10 @@ impl WorkspaceSettingsOps {
                     ui.add_space(SETTINGS_TOGGLE_SPACING);
                     if ui
                         .add(
-                            egui::Button::new(&crate::i18n::I18nOps::get().common.advanced_settings)
-                                .frame_when_inactive(true),
+                            egui::Button::new(
+                                &crate::i18n::I18nOps::get().common.advanced_settings,
+                            )
+                            .frame_when_inactive(true),
                         )
                         .clicked()
                     {
@@ -87,7 +76,11 @@ impl WorkspaceSettingsOps {
                         if let Some(parent) = json_path.parent() {
                             let _ = std::fs::create_dir_all(parent);
                         }
-                        if std::fs::write(&json_path, "{\n  \"default\": true\n}\n").is_ok() {
+                        let config =
+                            crate::linter_config_bridge::MarkdownLinterConfigOps::load_effective_config(
+                                state,
+                            );
+                        if config.save(&json_path).is_ok() {
                             *is_advanced_open = true;
                         }
                     }
@@ -97,5 +90,54 @@ impl WorkspaceSettingsOps {
         .default_open(true)
         .force_open(force_open)
         .show(ui);
+    }
+
+    fn save_workspace_config_toggle(state: &mut crate::app_state::AppState, use_workspace: bool) {
+        state
+            .config
+            .settings
+            .settings_mut()
+            .linter
+            .use_workspace_local_config = use_workspace;
+        let _ = state.config.try_save_settings();
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use katana_core::workspace::Workspace;
+    use std::sync::Arc;
+
+    fn make_state(dir: &tempfile::TempDir) -> crate::app_state::AppState {
+        let mut state = crate::app_state::AppState::new(
+            Default::default(),
+            Default::default(),
+            katana_platform::SettingsService::default(),
+            Arc::new(katana_platform::InMemoryCacheService::default()),
+        );
+        state.workspace.data = Some(Workspace::new(dir.path(), Vec::new()));
+        state
+    }
+
+    #[test]
+    fn workspace_config_toggle_does_not_open_advanced_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".markdownlint.json"), "{}").unwrap();
+        let mut state = make_state(&dir);
+        let is_advanced_open = false;
+
+        WorkspaceSettingsOps::save_workspace_config_toggle(&mut state, true);
+
+        assert!(
+            state
+                .config
+                .settings
+                .settings()
+                .linter
+                .use_workspace_local_config
+        );
+        assert!(!is_advanced_open);
     }
 }

--- a/openspec/changes/v0-22-7-markdownlint-workspace-formatting/tasks.md
+++ b/openspec/changes/v0-22-7-markdownlint-workspace-formatting/tasks.md
@@ -29,14 +29,14 @@
 - [/] 同じ空き領域メニューに「ファイルの新規作成」「フォルダの新規作成」を追加する
 - [/] エクスプローラーのフィルター左にファイル追加・フォルダ追加アイコンを配置する
 - [/] 追加アイコンは `katana-icon-management` に従い、各 icon pack の native SVG を使う
-- [ ] `.markdownlint.json` に KatanA namespace を保存してよいか、KML と外部 markdownlint の互換性を実装時に確認する
+- [/] `.markdownlint.json` に KatanA namespace を保存してよいか、KML と外部 markdownlint の互換性を実装時に確認する
 - [ ] KML の format API がファイルパス、文字列、設定構造体のどれを受け取るか実装時に確認する
-- [ ] エディタ左端の Lint アイコンをホバーしても診断内容がポップ表示されない
+- [/] エディタ左端の Lint アイコンをホバーしても診断内容がポップ表示されない
 - [/] 行番号横の Lint アイコンは、多行診断でも問題 view と同じく診断の開始行だけに表示する
 - [ ] Task 2 着手前に、既存の Lint 設定 UI を前提にせず、設定画面全体の情報設計と操作導線を見直す
 - [ ] Lint 設定 UI は、通常の操作では設定 JSON をユーザーに意識させない設計思想を維持する
 - [ ] 詳しいユーザー向けに、KatanA 管理の共通ルールをワークスペースのルールとして展開する導線を用意する
-- [ ] ワークスペースに既存の markdownlint ルールファイルがある場合は、そのワークスペースのルールとして利用する
+- [/] ワークスペースに既存の markdownlint ルールファイルがある場合は、そのワークスペースのルールとして利用する
 - [ ] Lint の高度な設定は、アイコン設定の高度な設定と操作パターンを揃えつつ、内容は Lint ルール詳細として最適化する
 - [ ] Lint プリセットは、テーマ/アイコンと同じく選べるが、適用後は現在のルールへコピーするテンプレートとして扱う
 - [ ] 組み込みプリセットとして `KatanA`、`全て無効`、`厳格`、`すべて警告` を用意する
@@ -117,15 +117,15 @@ Task 2 は大きすぎるため、1ブランチに詰め込まず、以下のサ
 
 ### 2B. Lint Effective Config and Workspace Ownership
 
-- [ ] 2B.1 現在の `LinterSettings`、`MarkdownLinterConfigOps`、`MarkdownLinterOptionsBridgeOps` の責務を整理し、`workspace > global > default` の優先順位で effective config を解決する単一入口を追加または整理する
-- [ ] 2B.2 一般設定の「無視 / 警告 / エラー」と `.markdownlint.json` のルール適用設定の境界をテストで固定する
-- [ ] 2B.3 ワークスペース設定のオン/オフ切り替えで `linter_advanced_is_open` が変更されない回帰テストを追加する
-- [ ] 2B.4 一般設定の `RuleSeverity::Ignore` が、詳細設定を削除せず KatanA 側の診断抑制として働くことを実装する
-- [ ] 2B.5 `Ignore` から `Warning` / `Error` に戻した時、保持していた詳細設定が復元されることを実装する
-- [ ] 2B.6 `.markdownlint.json` に KatanA namespace を保存できるか検証し、不可の場合は既存 workspace state に重大度だけを保存する方針へ確定する
-- [ ] 2B.7 KatanA 管理の共通ルールを、ワークスペースのルールとして展開する操作を設計・実装する
-- [ ] 2B.8 KML に渡す config を、ファイルパスまたは KML が要求する構造体として確実に渡し、診断とフォーマットが同じ effective config を使うことをテストする
-- [ ] 2B.9 既存のワークスペースルールがある場合に、それを優先して読み込み、設定画面を開いただけでプリセットや共通ルールに上書きしないことをテストする
+- [x] 2B.1 現在の `LinterSettings`、`MarkdownLinterConfigOps`、`MarkdownLinterOptionsBridgeOps` の責務を整理し、`workspace > global > default` の優先順位で effective config を解決する単一入口を追加または整理する
+- [x] 2B.2 一般設定の「無視 / 警告 / エラー」と `.markdownlint.json` のルール適用設定の境界をテストで固定する
+- [x] 2B.3 ワークスペース設定のオン/オフ切り替えで `linter_advanced_is_open` が変更されない回帰テストを追加する
+- [x] 2B.4 一般設定の `RuleSeverity::Ignore` が、詳細設定を削除せず KatanA 側の診断抑制として働くことを実装する
+- [x] 2B.5 `Ignore` から `Warning` / `Error` に戻した時、保持していた詳細設定が復元されることを実装する
+- [x] 2B.6 `.markdownlint.json` に KatanA namespace を保存できるか検証し、不可の場合は既存 workspace state に重大度だけを保存する方針へ確定する
+- [x] 2B.7 KatanA 管理の共通ルールを、ワークスペースのルールとして展開する操作を設計・実装する
+- [x] 2B.8 KML に渡す診断 config を、ファイルパスまたは KML が要求する構造体として確実に渡す。フォーマット側は Task 3 の action 実装時に同じ effective config 入口へ接続する
+- [x] 2B.9 既存のワークスペースルールがある場合に、それを優先して読み込み、設定画面を開いただけでプリセットや共通ルールに上書きしないことをテストする
 
 ### 2C. Shared Preset Widget and Settings UI
 
@@ -172,7 +172,7 @@ Task 2 は大きすぎるため、1ブランチに詰め込まず、以下のサ
 - [ ] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
 - [ ] Base branch is synced, and a new branch is explicitly created for this task.
 
-- [ ] 3.1 KML の format API を確認し、必要なら `katana-markdown-linter` の workspace dependency を更新する
+- [ ] 3.1 KML の format API を確認し、必要なら `katana-markdown-linter` の workspace dependency を更新し、2B で追加した effective config 入口をフォーマットにも使う
 - [ ] 3.2 ファイル単位の Markdown フォーマットを行う action とサービスを追加する
 - [ ] 3.3 ワークスペース内の Markdown を一括フォーマットする action とサービスを追加する
 - [ ] 3.4 一括フォーマット対象から hidden infrastructure directory を除外する


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)
Task 2B: Lint の有効設定解決とワークスペース設定の所有範囲を整理しました。

## 対応内容 (Changes Made)
- workspace > global > default の優先順位で effective config（実際に適用される設定）を解決する入口を追加
- 一般設定の警告/エラーが .markdownlint.json 側で無効化された rule を再有効化しないよう修正
- 一般設定の無視は詳細設定を消さず、戻した時に詳細設定が復元されるよう固定
- ワークスペース設定のオン/オフで高度な設定画面へ勝手に切り替わらないよう修正
- 既存のワークスペース .markdownlint.json/.jsonc を優先し、設定画面表示だけでは上書きしないよう整理

## 影響範囲 (Impact Scope)
- Lint 診断の設定解決
- Lint 設定画面のワークスペース設定操作
- OpenSpec v0.22.7 tasks.md の Task 2B 状態

## 動作確認結果 (Verification Results)
- make test-specific T=effective_config_path
- make test-specific T=katana_warning_does_not_reenable_disabled_markdownlint_rule
- make test-specific T=workspace_config_toggle_does_not_open_advanced_settings
- make test-specific T=evaluate_document_does_not_reenable_markdownlint_disabled_rule
- make test-specific T=katana_ignore_keeps_rule_properties_for_restore
- make test-specific T=katana_namespace_is_not_markdownlint_compatible
- make lint-impacted
- ./scripts/openspec validate v0-22-7-markdownlint-workspace-formatting
- git diff --check
- git push の pre-push hook