### PR TITLE
feat: レビュー用スクリーンショットシナリオを追加

### DIFF
--- a/crates/katana-ui/src/linter_bridge.rs
+++ b/crates/katana-ui/src/linter_bridge.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::Path};
+use std::{
+    collections::HashMap,
+    panic::{AssertUnwindSafe, catch_unwind},
+    path::Path,
+};
 
 use katana_markdown_linter::{
     LintOptions,
@@ -31,13 +35,16 @@ impl MarkdownLinterBridgeOps {
             }
         }
 
-        MarkdownLinterOps::evaluate_all(
-            path,
-            content,
-            linter_settings.enabled,
-            &severity_map,
-            &options.rules,
-        )
+        catch_unwind(AssertUnwindSafe(|| {
+            MarkdownLinterOps::evaluate_all(
+                path,
+                content,
+                linter_settings.enabled,
+                &severity_map,
+                &options.rules,
+            )
+        }))
+        .unwrap_or_default()
     }
 
     pub(crate) fn has_applicable_fix(diag: &MarkdownDiagnostic) -> bool {
@@ -219,6 +226,24 @@ mod tests {
             diagnostics
                 .iter()
                 .all(|diagnostic| diagnostic.rule_id != "MD001")
+        );
+    }
+
+    #[test]
+    fn evaluate_document_contains_linter_panic_boundary() {
+        let state = make_state();
+        let multibyte_line = "\u{30f3}".repeat(30);
+
+        let diagnostics = MarkdownLinterBridgeOps::evaluate_document(
+            &state,
+            &PathBuf::from("doc.md"),
+            &multibyte_line,
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.rule_id.is_empty())
         );
     }
 

--- a/openspec/changes/v0-22-7-markdownlint-workspace-formatting/tasks.md
+++ b/openspec/changes/v0-22-7-markdownlint-workspace-formatting/tasks.md
@@ -241,9 +241,9 @@ Task 2 は大きすぎるため、1ブランチに詰め込まず、以下のサ
 ### Definition of Done (DoD)
 
 - [x] すべての icon pack でファイル追加・フォルダ追加アイコンが表示できること
-- [ ] 画像で示された「ファイル +」「フォルダ +」の意味が画面上で分かること
+- [x] 画像で示された「ファイル +」「フォルダ +」の意味が画面上で分かること
 - [x] 追加アイコンが `katana-icon-management` の運用に従っていること
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+- [x] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ---
 
@@ -251,13 +251,14 @@ Task 2 は大きすぎるため、1ブランチに詰め込まず、以下のサ
 
 ### Definition of Ready (DoR)
 
-- [ ] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
-- [ ] Base branch is synced, and a new branch is explicitly created for this task.
+- [x] Ensure the previous task completed its full delivery cycle: self-review, recovery (if needed), PR creation, merge, and branch deletion.
+- [x] Base branch is synced, and a new branch is explicitly created for this task.
 
 > ユーザーレビューで指摘された問題点。対応後に `[/]` でクローズする（通常のタスク `[x]` と区別するため）。
 
-- [ ] 6.1 ユーザーへ実装完了の報告および動作状況を提示する。UI の動作確認は、ユーザーに手動操作を依頼せず、`scripts/screenshot/run.sh --request <request.json> --output scripts/screenshot/output/v0-22-7-review` で生成したスクリーンショットまたは動画を提示して確認できる状態にする。シナリオ定義は git 管理対象、生成物は `.gitignore` 対象にする
+- [x] 6.1 ユーザーへ実装完了の報告および動作状況を提示する。UI の動作確認は、ユーザーに手動操作を依頼せず、`scripts/screenshot/run.sh --request <request.json> --output scripts/screenshot/output/v0-22-7-review` で生成したスクリーンショットまたは動画を提示して確認できる状態にする。シナリオ定義は git 管理対象、生成物は `.gitignore` 対象にする
 - [ ] 6.2 ユーザーから受けたフィードバック（技術的負債の指摘を含む）を本ドキュメント（tasks.md）に追記し、すべて対応・解決する（※個別劣後と指定されたものを除く）
+- [/] 6.3 確認シナリオで日本語本文を lint した際、外部 linter の MD013 が文字境界で panic する問題を検出した。KatanA 側の linter bridge で panic をアプリ全体へ伝播させず、回帰テストで固定する
 
 ### Definition of Done (DoD)
 

--- a/scripts/screenshot/examples/v0-22-7-review.json
+++ b/scripts/screenshot/examples/v0-22-7-review.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "1",
+  "name": "v0-22-7-review",
+  "fixture": {
+    "settings": {
+      "theme": "dark",
+      "locale": "ja",
+      "explorer_visible": true,
+      "linter_enabled": false
+    },
+    "workspace_files": [
+      {
+        "name": "README.md",
+        "content": "# v0.22.7 確認\n\nMarkdown ファイルの右クリックメニューと Explorer の作成ボタンを確認します。\n\n```mermaid\ngraph TD\n    A[開始] --> B[確認]\n```\n"
+      },
+      {
+        "name": "notes.txt",
+        "content": "Markdown ではないファイルです。\n"
+      }
+    ]
+  },
+  "steps": [
+    {
+      "type": "launch",
+      "viewport": { "width": 1280, "height": 800 },
+      "wait_seconds": 2.0
+    },
+    {
+      "type": "screenshot",
+      "output_name": "01-explorer-header-actions"
+    },
+    {
+      "type": "action",
+      "action": {
+        "click_at": {
+          "x": 145.0,
+          "y": 68.0,
+          "button": "secondary",
+          "wait_seconds": 0.6
+        }
+      }
+    },
+    {
+      "type": "screenshot",
+      "output_name": "02-markdown-file-context-menu"
+    },
+    {
+      "type": "action",
+      "action": {
+        "click_at": {
+          "x": 900.0,
+          "y": 140.0,
+          "button": "primary",
+          "wait_seconds": 0.3
+        }
+      }
+    },
+    {
+      "type": "action",
+      "action": {
+        "click_at": {
+          "x": 150.0,
+          "y": 116.0,
+          "button": "secondary",
+          "wait_seconds": 0.6
+        }
+      }
+    },
+    {
+      "type": "screenshot",
+      "output_name": "03-workspace-root-context-menu"
+    },
+    {
+      "type": "action",
+      "action": {
+        "click_at": {
+          "x": 900.0,
+          "y": 140.0,
+          "button": "primary",
+          "wait_seconds": 0.3
+        }
+      }
+    },
+    {
+      "type": "action",
+      "action": {
+        "click_at": {
+          "x": 123.0,
+          "y": 35.0,
+          "button": "primary",
+          "wait_seconds": 0.8
+        }
+      }
+    },
+    {
+      "type": "screenshot",
+      "output_name": "04-new-file-modal"
+    },
+    {
+      "type": "quit"
+    }
+  ]
+}

--- a/scripts/screenshot/src/executor_harness.rs
+++ b/scripts/screenshot/src/executor_harness.rs
@@ -1,6 +1,6 @@
-use crate::request::{Fixture, ScrollDirection, Step, UiAction, VideoFormat};
+use crate::request::{ClickButton, Fixture, ScrollDirection, Step, UiAction, VideoFormat};
 use anyhow::{bail, Context, Result};
-use egui_kittest::Harness;
+use egui_kittest::{kittest::Queryable, Harness};
 use katana_core::workspace::TreeEntry;
 use katana_ui::app_state::{AppAction, AppState, SettingsSection, SettingsTab};
 use katana_ui::shell::KatanaApp;
@@ -558,6 +558,14 @@ pub fn run(
                             .trigger_action(AppAction::SelectDocument(path));
                         step_for_seconds(&mut harness, recording.as_mut(), 1.0)?;
                     }
+                    UiAction::ClickNode { label, button, wait_seconds } => {
+                        click_node(&mut harness, label, *button);
+                        step_for_seconds(&mut harness, recording.as_mut(), *wait_seconds)?;
+                    }
+                    UiAction::ClickAt { x, y, button, wait_seconds } => {
+                        click_at(&mut harness, egui::pos2(*x, *y), *button);
+                        step_for_seconds(&mut harness, recording.as_mut(), *wait_seconds)?;
+                    }
                     other => {
                         let app_action = match other {
                             UiAction::ToggleToc => AppAction::ToggleToc,
@@ -584,7 +592,9 @@ pub fn run(
                             | UiAction::RunDocumentSearch { .. }
                             | UiAction::SelectThemePresetInSettings { .. }
                             | UiAction::SlideshowNavigate { .. }
-                            | UiAction::SelectDemoTab { .. } => unreachable!(),
+                            | UiAction::SelectDemoTab { .. }
+                            | UiAction::ClickNode { .. }
+                            | UiAction::ClickAt { .. } => unreachable!(),
                         };
                         harness.state_mut().trigger_action(app_action);
                         let fps = recording.as_ref().map(|r| r.fps as u32).unwrap_or(60);
@@ -925,6 +935,35 @@ fn navigate_slideshow(
         step_for_seconds(harness, recording.as_deref_mut(), wait_seconds)?;
     }
     Ok(())
+}
+
+fn click_node(harness: &mut Harness<'_, KatanaApp>, label: &str, button: ClickButton) {
+    let node = harness.get_by_label(label);
+    match button {
+        ClickButton::Primary => node.click(),
+        ClickButton::Secondary => node.click_secondary(),
+    }
+}
+
+fn click_at(harness: &mut Harness<'_, KatanaApp>, pos: egui::Pos2, button: ClickButton) {
+    let pointer_button = match button {
+        ClickButton::Primary => egui::PointerButton::Primary,
+        ClickButton::Secondary => egui::PointerButton::Secondary,
+    };
+    harness.input_mut().events.push(egui::Event::PointerMoved(pos));
+    harness.input_mut().events.push(egui::Event::PointerButton {
+        pos,
+        button: pointer_button,
+        pressed: true,
+        modifiers: egui::Modifiers::NONE,
+    });
+    harness.input_mut().events.push(egui::Event::PointerButton {
+        pos,
+        button: pointer_button,
+        pressed: false,
+        modifiers: egui::Modifiers::NONE,
+    });
+    harness.step();
 }
 
 fn step_for_seconds(

--- a/scripts/screenshot/src/request.rs
+++ b/scripts/screenshot/src/request.rs
@@ -191,6 +191,17 @@ pub enum UiAction {
     SelectThemePresetInSettings { preset: String },
     /// Advance slideshow pages as if paging through fullscreen content.
     SlideshowNavigate { direction: String, steps: u32, wait_seconds: f64 },
+    /// Click a widget by its accessibility label.
+    ClickNode { label: String, button: ClickButton, wait_seconds: f64 },
+    /// Click a logical viewport coordinate.
+    ClickAt { x: f32, y: f32, button: ClickButton, wait_seconds: f64 },
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ClickButton {
+    Primary,
+    Secondary,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## 概要
- v0.22.7 のユーザーレビュー用スクリーンショットシナリオを追加
- スクリーンショットランナーにラベルクリックと座標クリックの操作を追加
- 確認中に見つかった外部 markdown linter の MD013 panic を KatanA 側で吸収し、アプリ全体へ伝播しないように修正
- OpenSpec tasks の Task 6.1 を更新

## 確認
- make test-specific T=evaluate_document_contains_linter_panic_boundary
- make test-specific T=evaluate_document_applies_katana_severity_overrides
- /opt/homebrew/bin/rtk cargo check -p katana-ui
- /opt/homebrew/bin/rtk cargo check --manifest-path scripts/screenshot/Cargo.toml
- make fmt-check
- make ast-lint
- make lint-impacted
- ./scripts/openspec validate v0-22-7-markdownlint-workspace-formatting
- ./scripts/screenshot/run.sh --request scripts/screenshot/examples/v0-22-7-review.json --output scripts/screenshot/output/v0-22-7-review
- git diff --check
- git push の pre-push hook

## 生成物
- scripts/screenshot/output/v0-22-7-review/01-explorer-header-actions.png
- scripts/screenshot/output/v0-22-7-review/02-markdown-file-context-menu.png
- scripts/screenshot/output/v0-22-7-review/03-workspace-root-context-menu.png
- scripts/screenshot/output/v0-22-7-review/04-new-file-modal.png

生成物は .gitignore 対象で、シナリオ定義だけを git 管理しています。
