### PR TITLE
docs: Mermaid出力契約の調査結果を記録

### DIFF
--- a/openspec/changes/v0-22-10-mermaid-rendering-compatibility-investigation/FINDINGS.md
+++ b/openspec/changes/v0-22-10-mermaid-rendering-compatibility-investigation/FINDINGS.md
@@ -1,0 +1,56 @@
+# Findings: v0.22.10 Mermaid Rendering Compatibility Investigation
+
+## 1. `mmdc` 由来の出力契約
+
+### 旧 KatanA の呼び出し
+
+旧 Mermaid renderer は、`4f273fff^` 時点の `crates/katana-core/src/markdown/mermaid_renderer/render.rs` で `mmdc` を直接起動していた。
+
+- 入力: 一時 `.mmd` ファイルを `-i` へ渡す
+- 出力: 入力ファイルと同じ一時ディレクトリの `.png` を `-o` へ渡す
+- 背景: `DiagramColorPreset::current().background` を `--backgroundColor` へ渡す
+- テーマ: `DiagramColorPreset::current().mermaid_theme` を `--theme` へ渡す
+- ログ: `--quiet` を付け、標準出力と標準エラーは捨てる
+- 形式: `mmdc` が出力ファイル拡張子 `.png` から PNG を選ぶ
+
+旧コードは `mmdc` を使う理由を「Puppeteer / Chrome で PNG 化し、`resvg` が苦手な `<foreignObject>` の欠落を避けるため」と記録していた。ここで必要だったのは `mmdc` 自体ではなく、公式 Mermaid.js をブラウザ互換の描画環境で実行し、PNG として安定して切り出す契約である。
+
+### `mmdc` 11.12.0 の既定値
+
+ローカルの `/opt/homebrew/bin/mmdc` と npm registry はどちらも `@mermaid-js/mermaid-cli` 11.12.0 を指していた。
+
+`mmdc -h` で確認した主な既定値は次の通り。
+
+- ページ幅（`--width`）: `800`
+- ページ高さ（`--height`）: `600`
+- 拡大率（`--scale`）: `1`
+- 背景色（`--backgroundColor`）: `white`
+- テーマ（`--theme`）: `default`
+- 出力形式（`--outputFormat`）: 出力ファイル拡張子から決定
+
+旧 KatanA は width / height / scale を明示していなかったため、`mmdc` 側の `800 x 600` と `scale = 1` が暗黙の基準だった。一方、背景色とテーマは KatanA の現在テーマから明示的に渡していた。
+
+### `mmdc` を依存として戻さない条件
+
+`mmdc` は実行時依存として戻さない。戻さない理由は次の通り。
+
+- Node.js と Mermaid CLI の導入をユーザーに要求し、KatanA のネイティブアプリ方針から外れる
+- `mmdc` の内部 runtime は Puppeteer / Chrome 依存であり、OS や配布形態ごとの差分が KatanA の外へ漏れる
+- 現行の Mermaid.js renderer はローカル `mermaid.min.js` を KatanA 側で管理しており、必要な契約を KatanA 側の描画 policy として持てる
+- 実行時の退避経路（fallback）を追加すると、preview と export の失敗条件、キャッシュ、検証対象が二重化する
+
+### KatanA renderer に取り込む policy
+
+KatanA 側で明示的に持つべき出力契約は次の通り。
+
+- render width: `mmdc` 既定の `800` を基準値にする
+- page height: `mmdc` 既定の `600` は初期表示領域の参考にし、最終 PNG は図形内容に合わせて切り出す
+- background: KatanA の `DiagramColorPreset.background` を HTML、SVG、PNG capture に通す
+- theme: KatanA の `DiagramColorPreset.mermaid_theme` を Mermaid 初期化へ通す
+- scale: 既定は `1` を互換基準とし、KatanA 側の高精細化は policy と cache key で明示する
+- capture target: ページ全体ではなく図形コンテナを切り出し、過度な余白を作らない
+- content bounds: SVG の `getBBox()` と `viewBox` を使い、図形内容と最小余白を基準にする
+- max width: 横長化を抑える上限を設け、ガントチャートの範囲外 today marker のような特殊マーカーは対象を限定して扱う
+- cache key: policy を変更した場合は cache version を更新し、旧 PNG と混在させない
+
+現行コードは `MERMAID_RENDER_WIDTH = 800`、`MERMAID_CAPTURE_SCALE = 1.25`、`MERMAID_CAPTURE_MAX_WIDTH = 1200` を持っている。`scale = 1.25` は `mmdc` 既定値とは異なるため、画質向上のための KatanA policy として扱い、検証と cache key の対象に含める。

--- a/openspec/changes/v0-22-10-mermaid-rendering-compatibility-investigation/tasks.md
+++ b/openspec/changes/v0-22-10-mermaid-rendering-compatibility-investigation/tasks.md
@@ -37,11 +37,11 @@
 
 ### 完了条件（Definition of Done）
 
-- [ ] 1.1 旧 KatanA が `mmdc` に渡していた引数（backgroundColor, theme, input, output, quiet）を確認する
-- [ ] 1.2 `mmdc` の既定 width / height / scale / backgroundColor を確認する
-- [ ] 1.3 `mmdc` 依存として戻さない条件を `FINDINGS.md` に明記する
-- [ ] 1.4 KatanA renderer に取り込むべき出力契約を policy として整理する
-- [ ] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
+- [x] 1.1 旧 KatanA が `mmdc` に渡していた引数（backgroundColor, theme, input, output, quiet）を確認する
+- [x] 1.2 `mmdc` の既定 width / height / scale / backgroundColor を確認する
+- [x] 1.3 `mmdc` 依存として戻さない条件を `FINDINGS.md` に明記する
+- [x] 1.4 KatanA renderer に取り込むべき出力契約を policy として整理する
+- [x] Execute `/openspec-delivery` workflow (`.agents/workflows/openspec-delivery.md`) to run the comprehensive delivery routine (Self-review, Commit, PR Creation, and Merge).
 
 ---
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)

v0.22.10 Task 1 として、旧 mmdc 経路が担っていた Mermaid 出力契約を調査し、OpenSpec の調査結果へ記録しました。

## 対応内容 (Changes Made)

- 旧 KatanA が mmdc に渡していた input / output / backgroundColor / theme / quiet を整理
- mmdc 11.12.0 の既定 width / height / scale / backgroundColor を確認
- mmdc を実行時依存として戻さない条件を明記
- KatanA renderer に取り込む render width / background / theme / capture / cache policy を整理

## 影響範囲 (Impact Scope)

- openspec/changes/v0-22-10-mermaid-rendering-compatibility-investigation/FINDINGS.md
- openspec/changes/v0-22-10-mermaid-rendering-compatibility-investigation/tasks.md

## 動作確認結果 (Verification Results)

- ./scripts/openspec validate v0-22-10-mermaid-rendering-compatibility-investigation --strict: pass
- kml check --config .markdownlint.json openspec/changes/v0-22-10-mermaid-rendering-compatibility-investigation/FINDINGS.md openspec/changes/v0-22-10-mermaid-rendering-compatibility-investigation/tasks.md: pass
- make kml-check: 既存の README / CHANGELOG / vendor 由来の既存違反で失敗。今回差分の対象ファイル lint は pass。