### PR TITLE
release: v0.22.18 リリース準備

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -2,6 +2,14 @@
 
 KatanA Desktop における重要な変更点（アップデート）を記録します。
 
+## [0.22.18] - 2026-05-15 01:02:42 (JST)
+
+### 🐛 不具合修正
+
+- **Linux の図形内テキスト**: Linux 環境のプレビュー（preview）で Mermaid / Draw.io の図形内テキストが消える問題を修正しました。
+- **Linux の PlantUML 表示**: Linux 環境のプレビュー（preview）で PlantUML 図形が空白になる問題を修正しました。
+- **Windows の更新確認**: 壊れたローカル中継設定（local proxy）がある環境で、更新確認が `io: Connection refused` で失敗する問題を修正しました。
+
 ## [0.22.17] - 2026-05-13 23:30:56 (JST)
 
 ### 🐛 修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to KatanA Desktop. This file records the changes to KatanA Desktop.
 
+## [0.22.18] - 2026-05-14 16:02:42 (UTC)
+
+### 🐛 Bug Fixes
+
+- **Linux Diagram Labels**: Fixed Mermaid and Draw.io diagram labels disappearing in the preview on Linux.
+- **Linux PlantUML Preview**: Fixed PlantUML diagrams rendering as blank space in the preview on Linux.
+- **Windows Update Check**: Fixed update checks failing with `io: Connection refused` when Windows environments have a broken local proxy setting.
+
 ## [0.22.17] - 2026-05-13 14:30:56 (UTC)
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "katana-core"
-version = "0.22.17"
+version = "0.22.18"
 dependencies = [
  "anyhow",
  "base64",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "katana-linter"
-version = "0.22.17"
+version = "0.22.18"
 dependencies = [
  "ignore",
  "katana-ast-lint",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "katana-platform"
-version = "0.22.17"
+version = "0.22.18"
 dependencies = [
  "anyhow",
  "cc",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "katana-ui"
-version = "0.22.17"
+version = "0.22.18"
 dependencies = [
  "accesskit",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.22.17"
+version = "0.22.18"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/HiroyukiFuruno/KatanA"

--- a/crates/katana-core/src/markdown/svg_rasterize.rs
+++ b/crates/katana-core/src/markdown/svg_rasterize.rs
@@ -2,28 +2,19 @@
 Uses `resvg` + `usvg` to convert SVG text to an RGBA pixel buffer.
 Returns the result as raw bytes compatible with egui's `ColorImage`. */
 
+mod preprocess;
+mod types;
+
+pub use types::*;
+
 use resvg::{render, usvg};
 use tiny_skia::Pixmap;
 
 const MAX_RASTERIZED_SVG_EDGE: f32 = 8192.0;
-const LIGHT_DARK_FUNCTION: &str = "light-dark(";
-
-#[derive(Debug, Clone)]
-pub struct RasterizedSvg {
-    pub width: u32,
-    pub height: u32,
-    pub display_width: f32,
-    pub display_height: f32,
-    pub rgba: Vec<u8>,
-}
-
-pub struct SvgRasterizeOps;
 
 impl SvgRasterizeOps {
     pub fn preprocess_for_rasterizer(svg_text: &str) -> String {
-        let with_xml_entities = normalize_html_entities_for_xml(svg_text);
-        let without_foreign_objects = strip_foreign_objects(&with_xml_entities);
-        resolve_light_dark_functions(&without_foreign_objects)
+        preprocess::preprocess_for_rasterizer(svg_text)
     }
 
     pub fn rasterize_svg(svg_text: &str, scale: f32) -> Result<RasterizedSvg, SvgRasterizeError> {
@@ -63,66 +54,6 @@ impl SvgRasterizeOps {
     }
 }
 
-fn normalize_html_entities_for_xml(svg_text: &str) -> String {
-    svg_text.replace("&nbsp;", "&#160;")
-}
-
-fn strip_foreign_objects(svg_text: &str) -> String {
-    foreign_object_pattern()
-        .replace_all(svg_text, "")
-        .to_string()
-}
-
-fn foreign_object_pattern() -> &'static regex::Regex {
-    static PATTERN: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
-    PATTERN.get_or_init(|| {
-        regex::Regex::new(concat!(
-            r"(?is)<foreignObject\b[^>]*/>|",
-            r"<foreignObject\b[^>]*>.*?</foreignObject>"
-        ))
-        .expect("valid foreignObject regex")
-    })
-}
-
-fn resolve_light_dark_functions(svg_text: &str) -> String {
-    let mut result = String::with_capacity(svg_text.len());
-    let mut remaining = svg_text;
-    while let Some(start) = find_light_dark_function(remaining) {
-        let content_start = start + LIGHT_DARK_FUNCTION.len();
-        result.push_str(&remaining[..start]);
-        let Some((content_end, light_color)) =
-            parse_light_dark_function(&remaining[content_start..])
-        else {
-            result.push_str(&remaining[start..content_start]);
-            remaining = &remaining[content_start..];
-            continue;
-        };
-        result.push_str(light_color.trim());
-        remaining = &remaining[content_start + content_end + 1..];
-    }
-    result.push_str(remaining);
-    result
-}
-
-fn find_light_dark_function(text: &str) -> Option<usize> {
-    text.to_ascii_lowercase().find(LIGHT_DARK_FUNCTION)
-}
-
-fn parse_light_dark_function(content: &str) -> Option<(usize, &str)> {
-    let mut depth = 0usize;
-    let mut comma = None;
-    for (index, character) in content.char_indices() {
-        match character {
-            '(' => depth += 1,
-            ')' if depth == 0 => return comma.map(|comma_index| (index, &content[..comma_index])),
-            ')' => depth -= 1,
-            ',' if depth == 0 && comma.is_none() => comma = Some(index),
-            _ => {}
-        }
-    }
-    None
-}
-
 fn font_db() -> std::sync::Arc<usvg::fontdb::Database> {
     static FONT_DB: std::sync::OnceLock<std::sync::Arc<usvg::fontdb::Database>> =
         std::sync::OnceLock::new();
@@ -140,34 +71,21 @@ fn effective_scale(width: f32, height: f32, requested_scale: f32) -> f32 {
     positive_scale.min(width_scale).min(height_scale)
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum SvgRasterizeError {
-    #[error("Failed to parse SVG: {0}")]
-    ParseFailed(String),
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn preprocess_reuses_invalid_light_dark_syntax() {
-        let source = "<svg>fill: light-dark(red)</svg>";
-        let output = SvgRasterizeOps::preprocess_for_rasterizer(source);
-        assert_eq!(output, source);
-    }
-
-    #[test]
-    fn parse_light_dark_function_without_comma_returns_none() {
-        assert_eq!(parse_light_dark_function("red)"), None);
-        assert_eq!(parse_light_dark_function(""), None);
-    }
-
-    #[test]
-    fn parse_light_dark_function_with_nested_args() {
-        assert_eq!(
-            parse_light_dark_function("calc(1,2),ok)"),
-            Some((12, "calc(1,2)"))
+    fn rasterize_handles_plantuml_processing_instructions() {
+        let source = concat!(
+            r#"<?plantuml 1.2026.2?>"#,
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px">"#,
+            r##"<g><?plantuml-src abc?><rect width="20" height="20" fill="#2D2D2D"/>"##,
+            r##"<text x="2" y="12" fill="#E0E0E0">PUML</text></g></svg>"##
         );
+
+        let rasterized = SvgRasterizeOps::rasterize_svg(source, 1.0).expect("rasterize PlantUML");
+
+        assert!(rasterized.rgba.chunks_exact(4).any(|pixel| pixel[3] > 0));
     }
 }

--- a/crates/katana-core/src/markdown/svg_rasterize/preprocess.rs
+++ b/crates/katana-core/src/markdown/svg_rasterize/preprocess.rs
@@ -1,0 +1,89 @@
+mod foreign_object;
+mod light_dark;
+
+pub(super) fn preprocess_for_rasterizer(svg_text: &str) -> String {
+    let with_xml_entities = normalize_html_entities_for_xml(svg_text);
+    let without_plantuml_metadata = strip_plantuml_processing_instructions(&with_xml_entities);
+    let with_svg_text_fallbacks =
+        foreign_object::replace_with_text_fallbacks(&without_plantuml_metadata);
+    light_dark::resolve_functions(&with_svg_text_fallbacks)
+}
+
+fn normalize_html_entities_for_xml(svg_text: &str) -> String {
+    svg_text.replace("&nbsp;", "&#160;")
+}
+
+fn strip_plantuml_processing_instructions(svg_text: &str) -> String {
+    plantuml_processing_instruction_pattern()
+        .replace_all(svg_text, "")
+        .to_string()
+}
+
+fn plantuml_processing_instruction_pattern() -> &'static regex::Regex {
+    static PATTERN: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    PATTERN.get_or_init(|| {
+        regex::Regex::new(r"(?is)<\?plantuml(?:-src)?\b.*?\?>")
+            .expect("valid PlantUML processing instruction regex")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preprocess_reuses_invalid_light_dark_syntax() {
+        let source = "<svg>fill: light-dark(red)</svg>";
+        let output = preprocess_for_rasterizer(source);
+        assert_eq!(output, source);
+    }
+
+    #[test]
+    fn preprocess_converts_foreign_object_label_to_svg_text() {
+        let source = concat!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">"#,
+            r#"<foreignObject x="10" y="20" width="80" height="24">"#,
+            r#"<div xmlns="http://www.w3.org/1999/xhtml" "#,
+            r#"style="font-size: 12px; color: #E0E0E0;">Node &amp; Label</div>"#,
+            r#"</foreignObject></svg>"#
+        );
+
+        let output = preprocess_for_rasterizer(source);
+
+        assert!(!output.contains("<foreignObject"));
+        assert!(output.contains("<text"));
+        assert!(output.contains(r##"fill="#E0E0E0""##));
+        assert!(output.contains(">Node &amp; Label<"));
+    }
+
+    #[test]
+    fn preprocess_uses_existing_svg_text_in_switch_fallback() {
+        let source = concat!(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">"#,
+            r#"<switch><foreignObject x="10" y="20" width="80" height="24">"#,
+            r#"<div xmlns="http://www.w3.org/1999/xhtml">HTML Label</div>"#,
+            r#"</foreignObject><text x="10" y="20">SVG Label</text></switch></svg>"#
+        );
+
+        let output = preprocess_for_rasterizer(source);
+
+        assert!(!output.contains("<foreignObject"));
+        assert!(!output.contains("HTML Label"));
+        assert!(output.contains("SVG Label"));
+        assert_eq!(output.matches("<text").count(), 1);
+    }
+
+    #[test]
+    fn preprocess_removes_plantuml_processing_instructions() {
+        let source = concat!(
+            r#"<?plantuml 1.2026.2?>"#,
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px">"#,
+            r##"<g><?plantuml-src abc?><rect width="20" height="20" fill="#2D2D2D"/>"##,
+            r##"<text x="2" y="12" fill="#E0E0E0">PUML</text></g></svg>"##
+        );
+
+        let output = preprocess_for_rasterizer(source);
+
+        assert!(!output.contains("<?plantuml"));
+    }
+}

--- a/crates/katana-core/src/markdown/svg_rasterize/preprocess/foreign_object.rs
+++ b/crates/katana-core/src/markdown/svg_rasterize/preprocess/foreign_object.rs
@@ -1,0 +1,102 @@
+mod label;
+
+pub(super) fn replace_with_text_fallbacks(svg_text: &str) -> String {
+    let mut result = String::with_capacity(svg_text.len());
+    let mut last_end = 0usize;
+    for mat in foreign_object_pattern().find_iter(svg_text) {
+        result.push_str(&svg_text[last_end..mat.start()]);
+        if !has_svg_text_fallback_after(svg_text, mat.start(), mat.end())
+            && let Some(text) = label::to_svg_text(mat.as_str())
+        {
+            result.push_str(&text);
+        }
+        last_end = mat.end();
+    }
+    result.push_str(&svg_text[last_end..]);
+    result
+}
+
+fn foreign_object_pattern() -> &'static regex::Regex {
+    static PATTERN: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    PATTERN.get_or_init(|| {
+        regex::Regex::new(concat!(
+            r"(?is)<foreignObject\b[^>]*/>|",
+            r"<foreignObject\b[^>]*>.*?</foreignObject>"
+        ))
+        .expect("valid foreignObject regex")
+    })
+}
+
+fn has_svg_text_fallback_after(
+    svg_text: &str,
+    foreign_object_start: usize,
+    foreign_object_end: usize,
+) -> bool {
+    let before = &svg_text[..foreign_object_start];
+    let Some(switch_start) = before.rfind("<switch") else {
+        return false;
+    };
+    if before
+        .rfind("</switch>")
+        .is_some_and(|end| end > switch_start)
+    {
+        return false;
+    }
+
+    let after = &svg_text[foreign_object_end..];
+    let Some(switch_end) = after.find("</switch>") else {
+        return false;
+    };
+    let switch_tail = &after[..switch_end];
+    let Some(text_start) = switch_tail.find("<text") else {
+        return false;
+    };
+    switch_tail
+        .find("<foreignObject")
+        .is_none_or(|next_foreign_object| text_start < next_foreign_object)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_no_fallback_after_closed_switch() {
+        let source = concat!(
+            r#"<svg><switch></switch>"#,
+            r#"<foreignObject x="0" y="0"><div>Label</div></foreignObject></svg>"#
+        );
+        let (start, end) = foreign_object_range(source);
+
+        assert!(!has_svg_text_fallback_after(source, start, end));
+    }
+
+    #[test]
+    fn detects_no_fallback_without_switch_end() {
+        let source = concat!(
+            r#"<svg><switch>"#,
+            r#"<foreignObject x="0" y="0"><div>Label</div></foreignObject></svg>"#
+        );
+        let (start, end) = foreign_object_range(source);
+
+        assert!(!has_svg_text_fallback_after(source, start, end));
+    }
+
+    #[test]
+    fn detects_no_fallback_without_svg_text() {
+        let source = concat!(
+            r#"<svg><switch>"#,
+            r#"<foreignObject x="0" y="0"><div>Label</div></foreignObject>"#,
+            r#"<rect width="10" height="10"/></switch></svg>"#
+        );
+        let (start, end) = foreign_object_range(source);
+
+        assert!(!has_svg_text_fallback_after(source, start, end));
+    }
+
+    fn foreign_object_range(source: &str) -> (usize, usize) {
+        let start = source.find("<foreignObject").unwrap();
+        let end = source.find("</foreignObject>").unwrap() + "</foreignObject>".len();
+        (start, end)
+    }
+}

--- a/crates/katana-core/src/markdown/svg_rasterize/preprocess/foreign_object.rs
+++ b/crates/katana-core/src/markdown/svg_rasterize/preprocess/foreign_object.rs
@@ -32,6 +32,9 @@ fn has_svg_text_fallback_after(
     foreign_object_start: usize,
     foreign_object_end: usize,
 ) -> bool {
+    /* WHY: Plain substring search for `<switch` is safe because SVG 1.1 / 2 has no other
+    element name starting with `switch` (only `<switch>` exists), so any hit always opens
+    the `<switch>` container we care about. */
     let before = &svg_text[..foreign_object_start];
     let Some(switch_start) = before.rfind("<switch") else {
         return false;

--- a/crates/katana-core/src/markdown/svg_rasterize/preprocess/foreign_object/label.rs
+++ b/crates/katana-core/src/markdown/svg_rasterize/preprocess/foreign_object/label.rs
@@ -1,0 +1,231 @@
+const DEFAULT_FOREIGN_OBJECT_FONT_SIZE: f32 = 14.0;
+const FOREIGN_OBJECT_BASELINE_OFFSET_RATIO: f32 = 0.35;
+
+pub(super) fn to_svg_text(fragment: &str) -> Option<String> {
+    let element = xmltree::Element::parse(fragment.as_bytes()).ok()?;
+    let label = normalized_text_content(&element);
+    if label.is_empty() {
+        return None;
+    }
+
+    let x = parse_number_attr(&element, "x").unwrap_or(0.0);
+    let y = parse_number_attr(&element, "y").unwrap_or(0.0);
+    let width = parse_number_attr(&element, "width").unwrap_or(0.0);
+    let height = parse_number_attr(&element, "height").unwrap_or(0.0);
+    let font_size = find_style_property(&element, "font-size")
+        .as_deref()
+        .and_then(parse_leading_number)
+        .unwrap_or(DEFAULT_FOREIGN_OBJECT_FONT_SIZE);
+    let fill = find_style_property(&element, "color")
+        .or_else(|| find_style_property(&element, "fill"))
+        .or_else(|| find_attr_recursive(&element, "fill").map(ToString::to_string))
+        .unwrap_or_else(|| "currentColor".to_string());
+    let text_anchor = resolve_text_anchor(&element);
+    let text_x = match text_anchor {
+        "middle" => x + (width / 2.0),
+        "end" => x + width,
+        _ => x,
+    };
+    let text_y = if height > 0.0 {
+        y + (height / 2.0) + (font_size * FOREIGN_OBJECT_BASELINE_OFFSET_RATIO)
+    } else {
+        y + font_size
+    };
+
+    Some(format!(
+        r#"<text x="{x}" y="{y}" fill="{fill}" font-size="{font_size}" text-anchor="{anchor}">{label}</text>"#,
+        x = format_svg_number(text_x),
+        y = format_svg_number(text_y),
+        fill = escape_xml_attr(&fill),
+        font_size = format_svg_number(font_size),
+        anchor = text_anchor,
+        label = escape_xml_text(&label),
+    ))
+}
+
+fn normalized_text_content(element: &xmltree::Element) -> String {
+    let mut text = String::new();
+    collect_text_content(element, &mut text);
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn collect_text_content(element: &xmltree::Element, output: &mut String) {
+    for child in &element.children {
+        match child {
+            xmltree::XMLNode::Text(text) | xmltree::XMLNode::CData(text) => {
+                output.push(' ');
+                output.push_str(text);
+            }
+            xmltree::XMLNode::Element(child_element) => {
+                if child_element.name.eq_ignore_ascii_case("br") {
+                    output.push(' ');
+                }
+                collect_text_content(child_element, output);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn parse_number_attr(element: &xmltree::Element, name: &str) -> Option<f32> {
+    element
+        .attributes
+        .get(name)
+        .and_then(|value| parse_leading_number(value))
+}
+
+fn find_style_property(element: &xmltree::Element, property: &str) -> Option<String> {
+    element
+        .attributes
+        .get("style")
+        .and_then(|style| style_property(style, property))
+        .or_else(|| {
+            element.children.iter().find_map(|child| match child {
+                xmltree::XMLNode::Element(child_element) => {
+                    find_style_property(child_element, property)
+                }
+                _ => None,
+            })
+        })
+}
+
+fn style_property(style: &str, property: &str) -> Option<String> {
+    style.split(';').find_map(|declaration| {
+        let (name, value) = declaration.split_once(':')?;
+        name.trim()
+            .eq_ignore_ascii_case(property)
+            .then(|| value.trim().to_string())
+    })
+}
+
+fn find_attr_recursive<'a>(element: &'a xmltree::Element, name: &str) -> Option<&'a str> {
+    element
+        .attributes
+        .get(name)
+        .map(String::as_str)
+        .or_else(|| {
+            element.children.iter().find_map(|child| match child {
+                xmltree::XMLNode::Element(child_element) => {
+                    find_attr_recursive(child_element, name)
+                }
+                _ => None,
+            })
+        })
+}
+
+fn resolve_text_anchor(element: &xmltree::Element) -> &'static str {
+    find_style_property(element, "text-align")
+        .as_deref()
+        .map(str::trim)
+        .map(|align| {
+            if align.eq_ignore_ascii_case("right") {
+                "end"
+            } else if align.eq_ignore_ascii_case("left") {
+                "start"
+            } else {
+                "middle"
+            }
+        })
+        .unwrap_or("middle")
+}
+
+fn parse_leading_number(value: &str) -> Option<f32> {
+    let number_end = value
+        .char_indices()
+        .find_map(|(index, character)| {
+            (!matches!(character, '0'..='9' | '.' | '-' | '+')).then_some(index)
+        })
+        .unwrap_or(value.len());
+    value[..number_end].trim().parse::<f32>().ok()
+}
+
+fn format_svg_number(value: f32) -> String {
+    if value.fract().abs() < f32::EPSILON {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.3}")
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_string()
+    }
+}
+
+fn escape_xml_text(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn escape_xml_attr(text: &str) -> String {
+    escape_xml_text(text).replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_right_aligned_label_to_end_anchor() {
+        let output = to_svg_text(concat!(
+            r#"<foreignObject x="10" y="20" width="80" height="24">"#,
+            r#"<div xmlns="http://www.w3.org/1999/xhtml" "#,
+            r#"style="text-align: right; color: #fff;">Right</div></foreignObject>"#
+        ))
+        .unwrap();
+
+        assert!(output.contains(r#"x="90""#));
+        assert!(output.contains(r#"text-anchor="end""#));
+    }
+
+    #[test]
+    fn converts_left_aligned_label_to_start_anchor() {
+        let output = to_svg_text(concat!(
+            r#"<foreignObject x="10" y="20" width="80" height="0">"#,
+            r#"<div xmlns="http://www.w3.org/1999/xhtml" "#,
+            r#"style="text-align: left; font-size: 12px;">Left</div></foreignObject>"#
+        ))
+        .unwrap();
+
+        assert!(output.contains(r#"x="10""#));
+        assert!(output.contains(r#"y="32""#));
+        assert!(output.contains(r#"text-anchor="start""#));
+    }
+
+    #[test]
+    fn converts_center_aligned_label_to_middle_anchor() {
+        let output = to_svg_text(concat!(
+            r#"<foreignObject x="10" y="20" width="80" height="24">"#,
+            r#"<div xmlns="http://www.w3.org/1999/xhtml" "#,
+            r#"style="text-align: center;">Center</div></foreignObject>"#
+        ))
+        .unwrap();
+
+        assert!(output.contains(r#"x="50""#));
+        assert!(output.contains(r#"text-anchor="middle""#));
+    }
+
+    #[test]
+    fn uses_nested_fill_attribute_when_style_color_is_missing() {
+        let output = to_svg_text(concat!(
+            r#"<foreignObject x="0" y="0" width="20" height="20">"#,
+            r#"<div xmlns="http://www.w3.org/1999/xhtml">"#,
+            r##"<span fill="#123456">Nested</span><!-- ignored --></div></foreignObject>"##
+        ))
+        .unwrap();
+
+        assert!(output.contains(r##"fill="#123456""##));
+        assert!(output.contains(">Nested<"));
+    }
+
+    #[test]
+    fn normalizes_line_breaks_in_label_text() {
+        let output = to_svg_text(concat!(
+            r#"<foreignObject x="0" y="0" width="80" height="20">"#,
+            r#"<div xmlns="http://www.w3.org/1999/xhtml">First<br/>Second</div>"#,
+            r#"</foreignObject>"#
+        ))
+        .unwrap();
+
+        assert!(output.contains(">First Second<"));
+    }
+}

--- a/crates/katana-core/src/markdown/svg_rasterize/preprocess/light_dark.rs
+++ b/crates/katana-core/src/markdown/svg_rasterize/preprocess/light_dark.rs
@@ -1,0 +1,59 @@
+const LIGHT_DARK_FUNCTION: &str = "light-dark(";
+
+pub(super) fn resolve_functions(svg_text: &str) -> String {
+    let mut result = String::with_capacity(svg_text.len());
+    let mut remaining = svg_text;
+    while let Some(start) = find_light_dark_function(remaining) {
+        let content_start = start + LIGHT_DARK_FUNCTION.len();
+        result.push_str(&remaining[..start]);
+        let Some((content_end, light_color)) =
+            parse_light_dark_function(&remaining[content_start..])
+        else {
+            result.push_str(&remaining[start..content_start]);
+            remaining = &remaining[content_start..];
+            continue;
+        };
+        result.push_str(light_color.trim());
+        remaining = &remaining[content_start + content_end + 1..];
+    }
+    result.push_str(remaining);
+    result
+}
+
+fn find_light_dark_function(text: &str) -> Option<usize> {
+    text.to_ascii_lowercase().find(LIGHT_DARK_FUNCTION)
+}
+
+fn parse_light_dark_function(content: &str) -> Option<(usize, &str)> {
+    let mut depth = 0usize;
+    let mut comma = None;
+    for (index, character) in content.char_indices() {
+        match character {
+            '(' => depth += 1,
+            ')' if depth == 0 => return comma.map(|comma_index| (index, &content[..comma_index])),
+            ')' => depth -= 1,
+            ',' if depth == 0 && comma.is_none() => comma = Some(index),
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_light_dark_function_without_comma_returns_none() {
+        assert_eq!(parse_light_dark_function("red)"), None);
+        assert_eq!(parse_light_dark_function(""), None);
+    }
+
+    #[test]
+    fn parse_light_dark_function_with_nested_args() {
+        assert_eq!(
+            parse_light_dark_function("calc(1,2),ok)"),
+            Some((12, "calc(1,2)"))
+        );
+    }
+}

--- a/crates/katana-core/src/markdown/svg_rasterize/types.rs
+++ b/crates/katana-core/src/markdown/svg_rasterize/types.rs
@@ -1,0 +1,16 @@
+#[derive(Debug, Clone)]
+pub struct RasterizedSvg {
+    pub width: u32,
+    pub height: u32,
+    pub display_width: f32,
+    pub display_height: f32,
+    pub rgba: Vec<u8>,
+}
+
+pub struct SvgRasterizeOps;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SvgRasterizeError {
+    #[error("Failed to parse SVG: {0}")]
+    ParseFailed(String),
+}

--- a/crates/katana-core/src/update/mod.rs
+++ b/crates/katana-core/src/update/mod.rs
@@ -1,6 +1,7 @@
 pub mod cleanup;
 pub mod download;
 pub mod installer;
+mod release_client;
 pub mod scripts;
 pub mod types;
 pub mod version;

--- a/crates/katana-core/src/update/release_client.rs
+++ b/crates/katana-core/src/update/release_client.rs
@@ -1,0 +1,169 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::io::ErrorKind;
+
+pub(super) const LATEST_RELEASE_API_URL: &str =
+    "https://api.github.com/repos/HiroyukiFuruno/KatanA/releases/latest";
+
+pub(super) struct LatestRelease {
+    pub(super) tag_name: String,
+    pub(super) html_url: String,
+    pub(super) body: String,
+}
+
+pub(super) struct ReleaseClient;
+
+impl ReleaseClient {
+    pub(super) fn fetch_latest_release(url: &str) -> Result<LatestRelease> {
+        match Self::fetch_with_agent(url, &ureq::Agent::new_with_defaults()) {
+            Ok(release) => Ok(release),
+            Err(error) if Self::should_retry_without_proxy(&error) => {
+                Self::fetch_with_agent(url, &Self::direct_agent()).map_err(Into::into)
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn direct_agent() -> ureq::Agent {
+        let config = ureq::Agent::config_builder().proxy(None).build();
+        ureq::Agent::new_with_config(config)
+    }
+
+    fn fetch_with_agent(url: &str, agent: &ureq::Agent) -> Result<LatestRelease, ureq::Error> {
+        let payload = agent
+            .get(url)
+            .header("User-Agent", "KatanA-Update-Manager")
+            .header("Accept", "application/vnd.github+json")
+            .call()?
+            .body_mut()
+            .read_json::<GitHubReleasePayload>()?;
+        Ok(payload.into())
+    }
+
+    fn should_retry_without_proxy(error: &ureq::Error) -> bool {
+        if ureq::Proxy::try_from_env().is_none() {
+            return false;
+        }
+
+        match error {
+            ureq::Error::Io(error) => error.kind() == ErrorKind::ConnectionRefused,
+            ureq::Error::ConnectProxyFailed(message) => {
+                message.to_ascii_lowercase().contains("refused")
+            }
+            _ => false,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct GitHubReleasePayload {
+    tag_name: String,
+    html_url: String,
+    #[serde(default)]
+    body: String,
+}
+
+impl From<GitHubReleasePayload> for LatestRelease {
+    fn from(value: GitHubReleasePayload) -> Self {
+        Self {
+            tag_name: value.tag_name,
+            html_url: value.html_url,
+            body: value.body,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::Mutex;
+
+    static PROXY_ENV_MUTEX: Mutex<()> = Mutex::new(());
+    const PROXY_ENV_KEYS: &[&str] = &[
+        "all_proxy",
+        "ALL_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ];
+
+    struct EnvSnapshot {
+        values: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture() -> Self {
+            let values = PROXY_ENV_KEYS
+                .iter()
+                .map(|key| (*key, std::env::var(key).ok()))
+                .collect();
+            Self { values }
+        }
+
+        fn set_refusing_proxy() {
+            for key in [
+                "all_proxy",
+                "ALL_PROXY",
+                "https_proxy",
+                "HTTP_PROXY",
+                "http_proxy",
+            ] {
+                /* WHY: Environment variables are process-wide, so this test mutates them only
+                while holding PROXY_ENV_MUTEX. */
+                unsafe { std::env::set_var(key, "http://127.0.0.1:1") };
+            }
+            for key in ["NO_PROXY", "no_proxy"] {
+                /* WHY: localhost proxy bypass would hide the refused-proxy regression. */
+                unsafe { std::env::remove_var(key) };
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (key, value) in &self.values {
+                match value {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn fetch_latest_release_retries_direct_when_env_proxy_refuses_connection() {
+        let _guard = PROXY_ENV_MUTEX.lock().unwrap();
+        let _snapshot = EnvSnapshot::capture();
+        EnvSnapshot::set_refusing_proxy();
+        let url = spawn_release_server(
+            r#"{"tag_name":"v9.9.9","html_url":"https://example.test/release","body":"notes"}"#,
+        );
+
+        let release = ReleaseClient::fetch_latest_release(&url).unwrap();
+
+        assert_eq!(release.tag_name, "v9.9.9");
+        assert_eq!(release.html_url, "https://example.test/release");
+        assert_eq!(release.body, "notes");
+    }
+
+    fn spawn_release_server(payload: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                payload.len(),
+                payload
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        format!("http://{address}/latest")
+    }
+}

--- a/crates/katana-core/src/update/release_client.rs
+++ b/crates/katana-core/src/update/release_client.rs
@@ -14,12 +14,20 @@ pub(super) struct LatestRelease {
 pub(super) struct ReleaseClient;
 
 impl ReleaseClient {
-    pub(super) fn fetch_latest_release(url: &str) -> Result<LatestRelease> {
-        match Self::fetch_with_agent(url, &ureq::Agent::new_with_defaults()) {
-            Ok(release) => Ok(release),
+    pub(super) fn fetch_latest_release(url: &str) -> Result<Option<LatestRelease>> {
+        let attempt = match Self::fetch_with_agent(url, &ureq::Agent::new_with_defaults()) {
+            Ok(release) => return Ok(Some(release)),
             Err(error) if Self::should_retry_without_proxy(&error) => {
-                Self::fetch_with_agent(url, &Self::direct_agent()).map_err(Into::into)
+                Self::fetch_with_agent(url, &Self::direct_agent())
             }
+            Err(error) => Err(error),
+        };
+        match attempt {
+            Ok(release) => Ok(Some(release)),
+            /* WHY: GitHub API rate limiting (403/429) or transient upstream denials should
+            be treated as "no update available" so the user does not see a confusing
+            failure dialog, matching the previous HTML-redirect implementation. */
+            Err(ureq::Error::StatusCode(_)) => Ok(None),
             Err(error) => Err(error.into()),
         }
     }
@@ -121,6 +129,12 @@ mod tests {
                 unsafe { std::env::remove_var(key) };
             }
         }
+
+        fn clear_proxy_env() {
+            for key in PROXY_ENV_KEYS {
+                unsafe { std::env::remove_var(key) };
+            }
+        }
     }
 
     impl Drop for EnvSnapshot {
@@ -143,7 +157,9 @@ mod tests {
             r#"{"tag_name":"v9.9.9","html_url":"https://example.test/release","body":"notes"}"#,
         );
 
-        let release = ReleaseClient::fetch_latest_release(&url).unwrap();
+        let release = ReleaseClient::fetch_latest_release(&url)
+            .unwrap()
+            .expect("release payload returned");
 
         assert_eq!(release.tag_name, "v9.9.9");
         assert_eq!(release.html_url, "https://example.test/release");
@@ -151,6 +167,10 @@ mod tests {
     }
 
     fn spawn_release_server(payload: &'static str) -> String {
+        spawn_release_server_with_status("HTTP/1.1 200 OK", payload)
+    }
+
+    fn spawn_release_server_with_status(status_line: &'static str, payload: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
         std::thread::spawn(move || {
@@ -158,12 +178,56 @@ mod tests {
             let mut request = [0; 1024];
             let _ = stream.read(&mut request);
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 payload.len(),
                 payload
             );
             stream.write_all(response.as_bytes()).unwrap();
         });
         format!("http://{address}/latest")
+    }
+
+    #[test]
+    fn fetch_latest_release_returns_none_on_non_2xx_status() {
+        let _guard = PROXY_ENV_MUTEX.lock().unwrap();
+        let _snapshot = EnvSnapshot::capture();
+        EnvSnapshot::clear_proxy_env();
+        let url = spawn_release_server_with_status("HTTP/1.1 403 Forbidden", "{}");
+
+        let result = ReleaseClient::fetch_latest_release(&url).unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn should_retry_returns_false_without_proxy_env() {
+        let _guard = PROXY_ENV_MUTEX.lock().unwrap();
+        let _snapshot = EnvSnapshot::capture();
+        EnvSnapshot::clear_proxy_env();
+        let error =
+            ureq::Error::Io(std::io::Error::new(ErrorKind::ConnectionRefused, "refused"));
+
+        assert!(!ReleaseClient::should_retry_without_proxy(&error));
+    }
+
+    #[test]
+    fn should_retry_returns_false_for_non_refused_io_error() {
+        let _guard = PROXY_ENV_MUTEX.lock().unwrap();
+        let _snapshot = EnvSnapshot::capture();
+        EnvSnapshot::set_refusing_proxy();
+        let error = ureq::Error::Io(std::io::Error::new(ErrorKind::TimedOut, "timeout"));
+
+        assert!(!ReleaseClient::should_retry_without_proxy(&error));
+    }
+
+    #[test]
+    fn should_retry_returns_true_for_connect_proxy_refused() {
+        let _guard = PROXY_ENV_MUTEX.lock().unwrap();
+        let _snapshot = EnvSnapshot::capture();
+        EnvSnapshot::set_refusing_proxy();
+        let error =
+            ureq::Error::ConnectProxyFailed("CONNECT failed: Connection refused".to_string());
+
+        assert!(ReleaseClient::should_retry_without_proxy(&error));
     }
 }

--- a/crates/katana-core/src/update/release_client.rs
+++ b/crates/katana-core/src/update/release_client.rs
@@ -170,7 +170,10 @@ mod tests {
         spawn_release_server_with_status("HTTP/1.1 200 OK", payload)
     }
 
-    fn spawn_release_server_with_status(status_line: &'static str, payload: &'static str) -> String {
+    fn spawn_release_server_with_status(
+        status_line: &'static str,
+        payload: &'static str,
+    ) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
         std::thread::spawn(move || {
@@ -204,8 +207,7 @@ mod tests {
         let _guard = PROXY_ENV_MUTEX.lock().unwrap();
         let _snapshot = EnvSnapshot::capture();
         EnvSnapshot::clear_proxy_env();
-        let error =
-            ureq::Error::Io(std::io::Error::new(ErrorKind::ConnectionRefused, "refused"));
+        let error = ureq::Error::Io(std::io::Error::new(ErrorKind::ConnectionRefused, "refused"));
 
         assert!(!ReleaseClient::should_retry_without_proxy(&error));
     }

--- a/crates/katana-core/src/update/version.rs
+++ b/crates/katana-core/src/update/version.rs
@@ -73,7 +73,9 @@ impl UpdateOps {
     }
 
     fn check_for_updates_from_url(current_version: &str, url: &str) -> Result<Option<ReleaseInfo>> {
-        let release = ReleaseClient::fetch_latest_release(url)?;
+        let Some(release) = ReleaseClient::fetch_latest_release(url)? else {
+            return Ok(None);
+        };
         let tag_version = release.tag_name.trim_start_matches('v');
         let curr_version = current_version.trim_start_matches('v');
 

--- a/crates/katana-core/src/update/version.rs
+++ b/crates/katana-core/src/update/version.rs
@@ -1,8 +1,6 @@
+use super::release_client::{LATEST_RELEASE_API_URL, ReleaseClient};
 use super::types::{ReleaseInfo, UpdateManager, UpdateOps};
 use anyhow::Result;
-use ureq::ResponseExt;
-
-const HTTP_OK: u16 = 200;
 
 impl UpdateOps {
     fn platform_asset_name() -> &'static str {
@@ -28,39 +26,9 @@ impl UpdateOps {
         let url = manager
             .api_url_override
             .as_deref()
-            .unwrap_or("https://github.com/HiroyukiFuruno/KatanA/releases/latest");
+            .unwrap_or(LATEST_RELEASE_API_URL);
 
-        let resp = ureq::get(url)
-            .header("User-Agent", "KatanA-Update-Manager")
-            .header("Accept", "text/html")
-            .call()?;
-
-        if resp.status() != HTTP_OK {
-            return Ok(None);
-        }
-
-        let final_url = resp.get_uri().to_string();
-        let tag_name = if let Some(idx) = final_url.rfind("releases/tag/") {
-            final_url[idx + "releases/tag/".len()..].to_string()
-        } else {
-            return Ok(None);
-        };
-
-        let tag_version = tag_name.trim_start_matches('v');
-        let curr_version = manager.current_version.trim_start_matches('v');
-
-        if !Self::is_newer_version(curr_version, tag_version) {
-            Ok(None)
-        } else {
-            let html_url = final_url.to_string();
-            let download_url = Self::build_download_url(&tag_name);
-            Ok(Some(ReleaseInfo {
-                tag_name,
-                html_url,
-                body: String::new(),
-                download_url,
-            }))
-        }
+        Self::check_for_updates_from_url(&manager.current_version, url)
     }
 
     pub fn is_newer_version(current: &str, latest: &str) -> bool {
@@ -101,36 +69,22 @@ impl UpdateOps {
     }
 
     pub fn check_for_updates_simple(current_version: &str) -> Result<Option<ReleaseInfo>> {
-        let url = "https://github.com/HiroyukiFuruno/KatanA/releases/latest";
+        Self::check_for_updates_from_url(current_version, LATEST_RELEASE_API_URL)
+    }
 
-        let resp = ureq::get(url)
-            .header("User-Agent", "KatanA-Update-Manager")
-            .header("Accept", "text/html")
-            .call()?;
-
-        if resp.status() != HTTP_OK {
-            return Ok(None);
-        }
-
-        let final_url = resp.get_uri().to_string();
-        let tag_name = if let Some(idx) = final_url.rfind("releases/tag/") {
-            final_url[idx + "releases/tag/".len()..].to_string()
-        } else {
-            return Ok(None);
-        };
-
-        let tag_version = tag_name.trim_start_matches('v');
+    fn check_for_updates_from_url(current_version: &str, url: &str) -> Result<Option<ReleaseInfo>> {
+        let release = ReleaseClient::fetch_latest_release(url)?;
+        let tag_version = release.tag_name.trim_start_matches('v');
         let curr_version = current_version.trim_start_matches('v');
 
         if !Self::is_newer_version(curr_version, tag_version) {
             Ok(None)
         } else {
-            let html_url = final_url.to_string();
-            let download_url = Self::build_download_url(&tag_name);
+            let download_url = Self::build_download_url(&release.tag_name);
             Ok(Some(ReleaseInfo {
-                tag_name,
-                html_url,
-                body: String::new(),
+                tag_name: release.tag_name,
+                html_url: release.html_url,
+                body: release.body,
                 download_url,
             }))
         }

--- a/crates/katana-ui/Info.plist
+++ b/crates/katana-ui/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>v0.22.17</string>
+    <string>v0.22.18</string>
     <key>CFBundleVersion</key>
     <string>2</string>
     <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)

v0.22.18 のリリース準備です。Linux 環境の図形プレビュー表示と、Windows 環境の更新確認失敗を修正します。

## 対応内容 (Changes Made)

- Linux プレビュー（preview）で Mermaid / Draw.io の図形内テキストが消える問題を修正
- Linux プレビュー（preview）で PlantUML 図形が空白になる問題を修正
- Windows の更新確認で、壊れたローカル中継設定（local proxy）がある場合に `io: Connection refused` で失敗する問題を修正
- v0.22.18 のバージョン更新と変更履歴を追加

## 影響範囲 (Impact Scope)

- Markdown プレビュー（preview）の図形ラスタライズ（SVG を画像として描画する処理）
- Mermaid / Draw.io / PlantUML の表示
- 更新確認処理
- Cargo.toml / Cargo.lock / Info.plist / CHANGELOG

## 動作確認結果 (Verification Results)

- `rtk just coverage`
- `rtk just fmt`
- `rtk git diff --check`
- `rtk just check-light`
- `rtk just check-linux`
- `rtk just check-windows`
- `rtk ./scripts/release/check-pr-ready.sh 0.22.18`
- ユーザー実行の `just check-local` が all checks passed になったため、明示許可に基づき commit / push で `--no-verify` を使用

## 自己レビュー (Self Review)

- 今回の差分のみを確認
- 本番コードに一時回避はなし
- 追加テストは分岐と回帰条件を直接検証
- 画像比較ではなく、SVG 変換結果とラスタライズ結果で検証
