### PR TITLE
fix(release): get-version.sh で release ブランチの descriptor suffix を正しく剥がす

### DIFF
--- a/scripts/release/get-version.sh
+++ b/scripts/release/get-version.sh
@@ -16,8 +16,20 @@ if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
     BARE="${INPUT_VERSION#v}"
     VERSION="v${BARE}"
 elif [ "${EVENT_NAME}" = "pull_request" ]; then
-    # PR from release branch: release/v0.18.5 -> 0.18.5
+    # PR from release branch: release/v0.18.5            -> 0.18.5
+    # PR from release branch: release/v0.22.22-something -> 0.22.22
     BARE="${PR_HEAD_REF#release/v}"
+    # WHY: Branch names sometimes carry a human-readable descriptor suffix
+    # (e.g. release/v0.22.22-headless-process-enforcement). check-pr-ready.sh's
+    # RELEASE_BRANCH_PATTERN already treats that suffix as optional and compares
+    # only the leading X.Y.Z against Cargo.toml. Mirror that contract here so the
+    # version_bare output passed downstream is the canonical X.Y.Z form.
+    # NOTE: This intentionally drops pre-release tokens such as `-rc.1`. KatanA
+    # does not ship pre-releases today; if that changes, this strip must be
+    # refined to preserve recognised pre-release suffixes.
+    if [[ "$BARE" =~ ^([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+        BARE="${BASH_REMATCH[1]}"
+    fi
     VERSION="v${BARE}"
 else
     # Tag push or other


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)

`release/v0.22.22-headless-process-enforcement` のような説明的 suffix 付き release ブランチを PR 経由でマージしたとき、build-and-release.yml の preflight が以下で fail していた：

```
[ERROR] Cargo.toml version (v0.22.22) does not match target version (v0.22.22-headless-process-enforcement).
```

PR #298 (v0.22.22) でこの事象が顕在化し、CD `Release` run 26021981370 が **Preflight Check** 段階で停止 → GitHub Release / artifact 未生成、という影響が出た。本 hotfix は CD pipeline 全体での version 抽出ルールを一意化して、suffix 付き branch でも CD が正常進行するようにする。

## 根本原因

CD pipeline 内で **同じ概念（release version）に対して 2 つの抽出ルール** が同居しており、互いに整合していなかった：

| ロケーション | 入力 | ルール | `release/v0.22.22-headless-process-enforcement` での結果 |
|---|---|---|---|
| `get-version.sh` (pull_request 分岐) | `PR_HEAD_REF` | 単純 prefix strip (`${PR_HEAD_REF#release/v}`) | `0.22.22-headless-process-enforcement` ← suffix 残る |
| `check-pr-ready.sh` (RELEASE_BRANCH_PATTERN) | `CURRENT_BRANCH` | regex で X.Y.Z と suffix を分離、`match[1]` | `0.22.22` |

→ get-version.sh の出力が `check-pr-ready.sh "<bare>"` の引数に渡されると、check-pr-ready.sh 側は Cargo.toml と引数を直接比較するため mismatch で exit 1。

## 対応内容 (Changes Made)

- `scripts/release/get-version.sh` の pull_request 分岐で、`${PR_HEAD_REF#release/v}` 後に **先頭の semver (X.Y.Z) のみ抽出する regex** を追加。check-pr-ready.sh と同じ contract で canonical な X.Y.Z を downstream に流す。
- pre-release token (`-rc.1` 等) も同時に剥がれる挙動になるため、コメントに「KatanA は現状 pre-release を出していないため許容。将来導入時は recognised pre-release token のみ保持するロジックに refine する」旨を明記。

## 影響範囲 (Impact Scope)

- `scripts/release/get-version.sh` のみ（13 行追加 / 1 行削除）
- アプリ本体（`crates/`）には変更なし → エンドユーザー影響なし
- 既存 release branch (`release/v0.22.21` 等 suffix なし) の挙動は変わらない（regression なし）
- CHANGELOG / Cargo.toml の version bump は不要（内部 release tooling の修正のため）

## 動作確認結果 (Verification Results)

`get-version.sh` を 5 ケースで手動実行し、すべて期待通りの結果を確認：

| ケース | 入力 | 期待 `version_bare` | 実測 |
|---|---|---|---|
| suffix なし PR | `release/v0.22.21` | `0.22.21` | ✅ `0.22.21` |
| suffix あり PR (今回の事象) | `release/v0.22.22-headless-process-enforcement` | `0.22.22` | ✅ `0.22.22` |
| workflow_dispatch (bare) | `0.22.22` | `0.22.22` | ✅ `0.22.22` |
| workflow_dispatch (v-prefix) | `v0.22.22` | `0.22.22` | ✅ `0.22.22` |
| tag push | `refs/tags/v0.22.22` | `0.22.22` | ✅ `0.22.22` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)