### PR TITLE
fix: release CI bypass を除去

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -113,6 +113,12 @@ jobs:
             "${{ github.ref }}" \
             "$GITHUB_OUTPUT"
 
+      - name: Verify CI gate for version bump merge
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/release/verify-version-bump-ci.sh "${{ github.event.pull_request.merge_commit_sha }}"
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - '**/*.rs'
       - '!scripts/**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'crates/katana-ui/Info.plist'
+      - '.github/workflows/**'
   pull_request:
     branches: [master]
     paths:
@@ -31,13 +35,6 @@ env:
 jobs:
   test:
     name: Test and Build
-    # WHY: Avoid redundant CI runs when a PR is merged, since tests already pass on the PR itself.
-    # Direct pushes to master without a PR merge will still trigger tests.
-    if: >-
-      github.event_name != 'push' || (
-        !startsWith(github.event.head_commit.message, 'Merge pull request ') &&
-        !contains(github.event.head_commit.message, '(#')
-      )
     strategy:
       fail-fast: false
       matrix:

--- a/crates/katana-linter/src/rules/domains/release_scripts.rs
+++ b/crates/katana-linter/src/rules/domains/release_scripts.rs
@@ -1,88 +1,23 @@
+mod ci_integrity;
+mod windows_packaging;
+
 use crate::Violation;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub struct ReleaseScriptOps;
 
 impl ReleaseScriptOps {
     pub fn lint(root: &Path) -> Vec<Violation> {
-        let script_path = root.join("scripts/build/package-windows.sh");
-        let content = match std::fs::read_to_string(&script_path) {
-            Ok(content) => content,
-            Err(error) => {
-                return vec![Self::violation(
-                    script_path,
-                    1,
-                    format!("Failed to read Windows package script: {error}"),
-                )];
-            }
-        };
-
-        let mut violations = Vec::new();
-        Self::lint_stale_msi_cleanup(&script_path, &content, &mut violations);
-        Self::lint_versioned_msi_selection(&script_path, &content, &mut violations);
-        Self::lint_unversioned_head_selection(&script_path, &content, &mut violations);
+        let mut violations = Self::lint_windows_msi_packaging(root);
+        violations.extend(Self::lint_ci_integrity(root));
         violations
     }
 
-    fn lint_stale_msi_cleanup(script_path: &Path, content: &str, violations: &mut Vec<Violation>) {
-        let cleanup_line = Self::line_number(content, "rm -f target/wix/*.msi");
-        let build_line = Self::line_number(content, "cargo wix --package katana-ui --nocapture");
-
-        if cleanup_line
-            .zip(build_line)
-            .is_none_or(|(cleanup, build)| cleanup >= build)
-        {
-            violations.push(Self::violation(
-                script_path.to_path_buf(),
-                build_line.unwrap_or(1),
-                "Delete stale target/wix MSI files before running cargo wix.".to_string(),
-            ));
-        }
+    pub fn lint_windows_msi_packaging(root: &Path) -> Vec<Violation> {
+        windows_packaging::WindowsPackagingOps::lint(root)
     }
 
-    fn lint_versioned_msi_selection(
-        script_path: &Path,
-        content: &str,
-        violations: &mut Vec<Violation>,
-    ) {
-        if Self::line_number(content, "-name \"*${CURRENT_VERSION}*.msi\"").is_none() {
-            violations.push(Self::violation(
-                script_path.to_path_buf(),
-                1,
-                "Select the MSI by CURRENT_VERSION so cached older installers cannot be copied."
-                    .to_string(),
-            ));
-        }
-    }
-
-    fn lint_unversioned_head_selection(
-        script_path: &Path,
-        content: &str,
-        violations: &mut Vec<Violation>,
-    ) {
-        if let Some(line) = Self::line_number(content, "-name '*.msi' -type f | head -n 1") {
-            violations.push(Self::violation(
-                script_path.to_path_buf(),
-                line,
-                "Do not copy the first MSI from target/wix; it may be a cached older version."
-                    .to_string(),
-            ));
-        }
-    }
-
-    fn line_number(content: &str, needle: &str) -> Option<usize> {
-        content
-            .lines()
-            .position(|line| line.contains(needle))
-            .map(|index| index + 1)
-    }
-
-    fn violation(file: PathBuf, line: usize, message: String) -> Violation {
-        Violation {
-            file,
-            line,
-            column: 1,
-            message,
-        }
+    pub fn lint_ci_integrity(root: &Path) -> Vec<Violation> {
+        ci_integrity::ReleaseCiIntegrityOps::lint(root)
     }
 }

--- a/crates/katana-linter/src/rules/domains/release_scripts/ci_integrity.rs
+++ b/crates/katana-linter/src/rules/domains/release_scripts/ci_integrity.rs
@@ -1,0 +1,185 @@
+use crate::Violation;
+use ignore::WalkBuilder;
+use std::path::{Path, PathBuf};
+
+pub(super) struct ReleaseCiIntegrityOps;
+
+impl ReleaseCiIntegrityOps {
+    const CI_BYPASS_MARKERS: [&'static str; 2] = ["[skip ci]", "[ci skip]"];
+    const BUMP_COMMIT_MESSAGE: &'static str = "chore: Release v${TARGET_VERSION}";
+    const RELEASE_CI_CAPABILITY: &'static str = "release-ci-integrity";
+
+    pub(super) fn lint(root: &Path) -> Vec<Violation> {
+        let mut violations = Vec::new();
+        Self::lint_no_ci_bypass_markers(root, &mut violations);
+        Self::lint_bump_commit_message(root, &mut violations);
+        violations
+    }
+
+    fn lint_no_ci_bypass_markers(root: &Path, violations: &mut Vec<Violation>) {
+        for file in Self::release_automation_files(root) {
+            let content = match std::fs::read_to_string(&file) {
+                Ok(content) => content,
+                Err(error) => {
+                    violations.push(Self::violation(
+                        file,
+                        1,
+                        format!("Failed to read release automation file: {error}"),
+                    ));
+                    continue;
+                }
+            };
+
+            Self::lint_file_for_ci_bypass_markers(&file, &content, violations);
+        }
+    }
+
+    fn lint_file_for_ci_bypass_markers(
+        file: &Path,
+        content: &str,
+        violations: &mut Vec<Violation>,
+    ) {
+        for marker in Self::CI_BYPASS_MARKERS {
+            if let Some(line) = Self::line_number(content, marker) {
+                violations.push(Self::violation(
+                    file.to_path_buf(),
+                    line,
+                    format!(
+                        "Do not embed CI bypass marker `{marker}` in release automation; capability `{}` forbids it.",
+                        Self::RELEASE_CI_CAPABILITY
+                    ),
+                ));
+            }
+        }
+    }
+
+    fn lint_bump_commit_message(root: &Path, violations: &mut Vec<Violation>) {
+        let script_path = root.join("scripts/release/bump-version.sh");
+        let content = match std::fs::read_to_string(&script_path) {
+            Ok(content) => content,
+            Err(error) => {
+                violations.push(Self::violation(
+                    script_path,
+                    1,
+                    format!("Failed to read release bump script: {error}"),
+                ));
+                return;
+            }
+        };
+
+        if Self::line_number(&content, Self::BUMP_COMMIT_MESSAGE).is_none() {
+            violations.push(Self::violation(
+                script_path,
+                1,
+                format!(
+                    "Release bump commits must use `{}` without CI bypass markers.",
+                    Self::BUMP_COMMIT_MESSAGE
+                ),
+            ));
+        }
+    }
+
+    fn release_automation_files(root: &Path) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+        Self::collect_files(root.join("scripts/release"), &mut files);
+        Self::collect_files(root.join(".github/workflows"), &mut files);
+        files.sort();
+        files
+    }
+
+    fn collect_files(root: PathBuf, files: &mut Vec<PathBuf>) {
+        if !root.exists() {
+            return;
+        }
+
+        let walker = WalkBuilder::new(root).standard_filters(true).build();
+        for entry in walker.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                files.push(path.to_path_buf());
+            }
+        }
+    }
+
+    fn line_number(content: &str, needle: &str) -> Option<usize> {
+        content
+            .lines()
+            .position(|line| line.contains(needle))
+            .map(|index| index + 1)
+    }
+
+    fn violation(file: PathBuf, line: usize, message: String) -> Violation {
+        Violation {
+            file,
+            line,
+            column: 1,
+            message,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rules::ReleaseScriptOps;
+    use std::path::Path;
+
+    #[test]
+    fn detects_ci_bypass_markers_in_release_automation() {
+        let temp_dir = tempfile::tempdir().expect("Test requirement");
+        write_file(
+            temp_dir.path().join("scripts/release/bump-version.sh"),
+            "git commit -m 'chore: Release v${TARGET_VERSION}'\n# [skip ci]\n",
+        );
+        write_file(
+            temp_dir.path().join(".github/workflows/release.yml"),
+            "message: chore: release [ci skip]\n",
+        );
+
+        let violations = ReleaseScriptOps::lint_ci_integrity(temp_dir.path());
+
+        assert_eq!(violations.len(), 2);
+        assert!(
+            violations
+                .iter()
+                .all(|it| { it.message.contains("release-ci-integrity") })
+        );
+    }
+
+    #[test]
+    fn accepts_release_bump_commit_message_without_bypass_marker() {
+        let temp_dir = tempfile::tempdir().expect("Test requirement");
+        write_file(
+            temp_dir.path().join("scripts/release/bump-version.sh"),
+            "git commit -S -n -m \"chore: Release v${TARGET_VERSION}\"\n",
+        );
+
+        let violations = ReleaseScriptOps::lint_ci_integrity(temp_dir.path());
+
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn rejects_release_bump_commit_message_without_expected_form() {
+        let temp_dir = tempfile::tempdir().expect("Test requirement");
+        write_file(
+            temp_dir.path().join("scripts/release/bump-version.sh"),
+            "git commit -S -n -m \"release ${TARGET_VERSION}\"\n",
+        );
+
+        let violations = ReleaseScriptOps::lint_ci_integrity(temp_dir.path());
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("chore: Release v${TARGET_VERSION}")
+        );
+    }
+
+    fn write_file(path: impl AsRef<Path>, content: &str) {
+        let path = path.as_ref();
+        let parent = path.parent().expect("Test requirement");
+        std::fs::create_dir_all(parent).expect("Test requirement");
+        std::fs::write(path, content).expect("Test requirement");
+    }
+}

--- a/crates/katana-linter/src/rules/domains/release_scripts/windows_packaging.rs
+++ b/crates/katana-linter/src/rules/domains/release_scripts/windows_packaging.rs
@@ -1,0 +1,88 @@
+use crate::Violation;
+use std::path::{Path, PathBuf};
+
+pub(super) struct WindowsPackagingOps;
+
+impl WindowsPackagingOps {
+    pub(super) fn lint(root: &Path) -> Vec<Violation> {
+        let script_path = root.join("scripts/build/package-windows.sh");
+        let content = match std::fs::read_to_string(&script_path) {
+            Ok(content) => content,
+            Err(error) => {
+                return vec![Self::violation(
+                    script_path,
+                    1,
+                    format!("Failed to read Windows package script: {error}"),
+                )];
+            }
+        };
+
+        let mut violations = Vec::new();
+        Self::lint_stale_msi_cleanup(&script_path, &content, &mut violations);
+        Self::lint_versioned_msi_selection(&script_path, &content, &mut violations);
+        Self::lint_unversioned_head_selection(&script_path, &content, &mut violations);
+        violations
+    }
+
+    fn lint_stale_msi_cleanup(script_path: &Path, content: &str, violations: &mut Vec<Violation>) {
+        let cleanup_line = Self::line_number(content, "rm -f target/wix/*.msi");
+        let build_line = Self::line_number(content, "cargo wix --package katana-ui --nocapture");
+
+        if cleanup_line
+            .zip(build_line)
+            .is_none_or(|(cleanup, build)| cleanup >= build)
+        {
+            violations.push(Self::violation(
+                script_path.to_path_buf(),
+                build_line.unwrap_or(1),
+                "Delete stale target/wix MSI files before running cargo wix.".to_string(),
+            ));
+        }
+    }
+
+    fn lint_versioned_msi_selection(
+        script_path: &Path,
+        content: &str,
+        violations: &mut Vec<Violation>,
+    ) {
+        if Self::line_number(content, "-name \"*${CURRENT_VERSION}*.msi\"").is_none() {
+            violations.push(Self::violation(
+                script_path.to_path_buf(),
+                1,
+                "Select the MSI by CURRENT_VERSION so cached older installers cannot be copied."
+                    .to_string(),
+            ));
+        }
+    }
+
+    fn lint_unversioned_head_selection(
+        script_path: &Path,
+        content: &str,
+        violations: &mut Vec<Violation>,
+    ) {
+        if let Some(line) = Self::line_number(content, "-name '*.msi' -type f | head -n 1") {
+            violations.push(Self::violation(
+                script_path.to_path_buf(),
+                line,
+                "Do not copy the first MSI from target/wix; it may be a cached older version."
+                    .to_string(),
+            ));
+        }
+    }
+
+    fn line_number(content: &str, needle: &str) -> Option<usize> {
+        content
+            .lines()
+            .position(|line| line.contains(needle))
+            .map(|index| index + 1)
+    }
+
+    fn violation(file: PathBuf, line: usize, message: String) -> Violation {
+        Violation {
+            file,
+            line,
+            column: 1,
+            message,
+        }
+    }
+}

--- a/crates/katana-linter/tests/ast_linter.rs
+++ b/crates/katana-linter/tests/ast_linter.rs
@@ -116,10 +116,21 @@ fn ast_linter_changelog_contains_current_workspace_version() {
 #[test]
 fn ast_linter_windows_msi_packaging_uses_current_version() {
     let root = LinterFileOps::workspace_root().expect("Test requirement");
-    let all_violations = ReleaseScriptOps::lint(root);
+    let all_violations = ReleaseScriptOps::lint_windows_msi_packaging(root);
     ViolationReporterOps::panic(
         "release-script-windows-msi-version",
         "Fix: Windows packaging must remove stale MSI files and copy only the MSI matching the current Cargo version.",
+        &all_violations,
+    );
+}
+
+#[test]
+fn ast_linter_release_automation_has_no_ci_bypass_markers() {
+    let root = LinterFileOps::workspace_root().expect("Test requirement");
+    let all_violations = ReleaseScriptOps::lint_ci_integrity(root);
+    ViolationReporterOps::panic(
+        "no-skip-ci-marker",
+        "Fix: release-ci-integrity forbids CI bypass markers in scripts/release/** and .github/workflows/**.",
         &all_violations,
     );
 }

--- a/openspec/changes/v0-22-25-update-dialog-i18n-and-release-ci-integrity/tasks.md
+++ b/openspec/changes/v0-22-25-update-dialog-i18n-and-release-ci-integrity/tasks.md
@@ -45,11 +45,20 @@ D. 更新確認 dialog の error 詳細部分が i18n 化されておらず、`u
 
 ### B. release CI integrity
 
-- [ ] B-1. `scripts/release/bump-version.sh` のローカル経路と CI 経路の双方から `[skip ci]` を撤廃する。
-- [ ] B-2. 撤廃を guard する `katana-linter` の新 rule `no-skip-ci-marker` を実装。`scripts/release/**/*.sh` と `.github/workflows/**` を grep ベースで検査。
-- [ ] B-3. ast_linter.rs の integration test に B-2 の rule を追加し、`[skip ci]` 文字列を含む fixture が違反扱いになることを保証。
-- [ ] B-4. Release workflow の preflight job で `git diff --name-only HEAD~1` を検査し、`Cargo.toml` / `Cargo.lock` / `Info.plist` のいずれかが差分に含まれる場合は paths-ignore を無効化して CI を強制発火させる。
-- [ ] B-5. bump-version.sh の unit test (またはスクリプト test) で commit message が `chore: Release v${VERSION}` 形式 (skip ci 文字列なし) であることを検証する。
+- [x] B-1. `scripts/release/bump-version.sh` のローカル経路と CI 経路の双方から `[skip ci]` を撤廃する。
+- [x] B-2. 撤廃を guard する `katana-linter` の新 rule `no-skip-ci-marker` を実装。`scripts/release/**/*.sh` と `.github/workflows/**` を grep ベースで検査。
+- [x] B-3. ast_linter.rs の integration test に B-2 の rule を追加し、`[skip ci]` 文字列を含む fixture が違反扱いになることを保証。
+- [x] B-4. Release workflow の preflight job で `git diff --name-only HEAD~1` を検査し、`Cargo.toml` / `Cargo.lock` / `Info.plist` のいずれかが差分に含まれる場合は paths-ignore を無効化して CI を強制発火させる。
+- [x] B-5. bump-version.sh の unit test (またはスクリプト test) で commit message が `chore: Release v${VERSION}` 形式 (skip ci 文字列なし) であることを検証する。
+
+#### B verification
+
+- [x] `rg -n "\[skip ci\]|\[ci skip\]" scripts/release .github/workflows` が該当なし。
+- [x] `cargo test -p katana-linter release_scripts --lib` が通過。
+- [x] `cargo test -p katana-linter --test ast_linter ast_linter_release_automation_has_no_ci_bypass_markers` が通過。
+- [x] `cargo test -p katana-linter --test ast_linter ast_linter_windows_msi_packaging_uses_current_version` が通過。
+- [x] `bash -n scripts/release/bump-version.sh scripts/release/verify-version-bump-ci.sh` が通過。
+- [x] `scripts/release/check-pr-ready.sh` が task branch / release prep 前の統合ブランチでは最終 release 検査を skip することを確認。
 
 ### C. OS-follow locale mode
 

--- a/scripts/release/bump-version.sh
+++ b/scripts/release/bump-version.sh
@@ -35,7 +35,7 @@ if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
     echo "🤖 Running in GitHub Actions. Using 'gh api' for verified commit..."
     
     BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-    COMMIT_MSG="chore: Release v${TARGET_VERSION} [skip ci]"
+    COMMIT_MSG="chore: Release v${TARGET_VERSION}"
     
     # Helper to update a file via GitHub API
     update_file() {
@@ -85,7 +85,7 @@ else
     if ! git diff --quiet Cargo.toml Cargo.lock "$INFO_PLIST"; then
         git add Cargo.toml Cargo.lock "$INFO_PLIST"
         # Local commits must keep the developer's configured identity so GitHub can match the signature.
-        git commit -S -n -m "chore: Release v${TARGET_VERSION} [skip ci]" -- Cargo.toml Cargo.lock "$INFO_PLIST"
+        git commit -S -n -m "chore: Release v${TARGET_VERSION}" -- Cargo.toml Cargo.lock "$INFO_PLIST"
         
         echo "✅ Version bump committed locally."
         echo "   (Note: Use 'git push' manually if the branch is not protected)"

--- a/scripts/release/check-pr-ready.sh
+++ b/scripts/release/check-pr-ready.sh
@@ -18,7 +18,9 @@ header() { printf "\n${BOLD}${CYAN}==> %s${RESET}\n" "$*"; }
 
 # Expected version from argument
 EXPECTED_VERSION=${1:-}
+HAS_EXPECTED_VERSION=false
 if [[ -n "$EXPECTED_VERSION" ]]; then
+    HAS_EXPECTED_VERSION=true
     EXPECTED_VERSION="${EXPECTED_VERSION#v}" # Strip leading v
 fi
 
@@ -26,7 +28,7 @@ fi
 is_ci() { [[ "${GITHUB_ACTIONS:-false}" == "true" ]]; }
 
 RELEASE_BRANCH_PATTERN='^release/v([0-9]+\.[0-9]+\.[0-9]+)(-[A-Za-z0-9][A-Za-z0-9._-]*)?$'
-TASK_BRANCH_PATTERN='^release/v[0-9]+\.[0-9]+\.[0-9]+-task-[0-9]+(-fix)?$'
+TASK_BRANCH_PATTERN='^release/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9._-]*)?-task-?[0-9A-Za-z]+(-fix)?$'
 
 # 1. Check for uncommitted changes (Local only)
 if ! is_ci; then
@@ -59,12 +61,18 @@ if [[ -n "$EXPECTED_VERSION" ]]; then
     TARGET_VERSION="$EXPECTED_VERSION"
     info "Target version set by argument: v${TARGET_VERSION}"
 elif [[ "$CURRENT_BRANCH" =~ $RELEASE_BRANCH_PATTERN ]]; then
-    # タスク用ブランチでは最終リリース準備まで Cargo.toml の version を上げない。
+    # Task branches do not bump Cargo.toml until final release preparation.
     if [[ "$CURRENT_BRANCH" =~ $TASK_BRANCH_PATTERN ]]; then
         success "Task branch detected (${CURRENT_BRANCH}). Skipping final PR readiness checks."
         exit 0
     fi
     TARGET_VERSION="${match[1]}"
+    if [[ "$HAS_EXPECTED_VERSION" == "false" && ! is_ci && "$CUR_VERSION" != "$TARGET_VERSION" ]]; then
+        warn "Release integration branch detected before final release preparation."
+        warn "Skipping final PR readiness checks until an explicit version is provided."
+        info "Run ./scripts/release/check-pr-ready.sh ${TARGET_VERSION} after release prep."
+        exit 0
+    fi
     info "Target version detected from branch: v${TARGET_VERSION}"
 else
     TARGET_VERSION="$CUR_VERSION"

--- a/scripts/release/verify-version-bump-ci.sh
+++ b/scripts/release/verify-version-bump-ci.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+COMMIT_SHA=${1:-}
+MAX_ATTEMPTS=${CI_GATE_WAIT_ATTEMPTS:-60}
+WAIT_SECONDS=${CI_GATE_WAIT_SECONDS:-30}
+VERSION_FILE_PATTERN='^(Cargo\.toml|Cargo\.lock|crates/katana-ui/Info\.plist)$'
+
+error() { printf '[ERROR] %s\n' "$*" >&2; }
+info() { printf '[INFO]  %s\n' "$*"; }
+success() { printf '[OK]    %s\n' "$*"; }
+
+if [ -z "$COMMIT_SHA" ]; then
+    error "Commit SHA is required."
+    exit 1
+fi
+
+if ! git rev-parse "${COMMIT_SHA}^" >/dev/null 2>&1; then
+    error "Cannot inspect parent commit for ${COMMIT_SHA}."
+    exit 1
+fi
+
+CHANGED_FILES=$(git diff --name-only "${COMMIT_SHA}^" "$COMMIT_SHA")
+if ! printf '%s\n' "$CHANGED_FILES" | grep -Eq "$VERSION_FILE_PATTERN"; then
+    success "No version file changes detected in ${COMMIT_SHA}; CI gate wait is not required."
+    exit 0
+fi
+
+info "Version file changes detected in ${COMMIT_SHA}; waiting for CI success on the same commit."
+
+for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
+    RUN_RECORD=$(gh run list \
+        --workflow test-and-build.yml \
+        --commit "$COMMIT_SHA" \
+        --event push \
+        --limit 20 \
+        --json status,conclusion,url,headSha \
+        --jq "map(select(.headSha == \"${COMMIT_SHA}\")) | first // empty | [.status, (.conclusion // \"\"), .url] | @tsv")
+
+    if [ -n "$RUN_RECORD" ]; then
+        IFS=$'\t' read -r STATUS CONCLUSION URL <<<"$RUN_RECORD"
+        if [ "$STATUS" = "completed" ] && [ "$CONCLUSION" = "success" ]; then
+            success "CI passed for ${COMMIT_SHA}: ${URL}"
+            exit 0
+        fi
+
+        if [ "$STATUS" = "completed" ]; then
+            error "CI completed without success for ${COMMIT_SHA}: ${CONCLUSION} (${URL})"
+            exit 1
+        fi
+
+        info "CI is ${STATUS} for ${COMMIT_SHA} (${ATTEMPT}/${MAX_ATTEMPTS})."
+    else
+        info "CI run is not visible yet for ${COMMIT_SHA} (${ATTEMPT}/${MAX_ATTEMPTS})."
+    fi
+
+    sleep "$WAIT_SECONDS"
+done
+
+error "Timed out waiting for CI success for ${COMMIT_SHA}."
+exit 1


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)
Task B: release CI integrity の実装です。

## 対応内容 (Changes Made)
- bump-version.sh のローカル経路と CI 経路から CI 回避文字列を撤廃
- scripts/release/** と .github/workflows/** の CI 回避文字列を検出する no-skip-ci-marker を追加
- version file を含む master push で CI が走るよう test-and-build.yml を修正
- release workflow preflight で version file 変更時に同一 commit の CI success を確認
- check-pr-ready.sh が release prep 前の task / integration branch を最終 release と誤認しないよう修正

## 影響範囲 (Impact Scope)
- release script
- GitHub Actions workflow
- katana-linter release script rule
- OpenSpec task state

## 動作確認結果 (Verification Results)
- rg -n "\[skip ci\]|\[ci skip\]" scripts/release .github/workflows: 該当なし
- cargo test -p katana-linter release_scripts --lib: pass
- cargo test -p katana-linter --test ast_linter ast_linter_release_automation_has_no_ci_bypass_markers: pass
- cargo test -p katana-linter --test ast_linter ast_linter_windows_msi_packaging_uses_current_version: pass
- cargo clippy -p katana-linter --all-targets -- -D warnings: pass
- zsh -n scripts/release/check-pr-ready.sh: pass
- bash -n scripts/release/bump-version.sh scripts/release/verify-version-bump-ci.sh: pass
- scripts/release/check-pr-ready.sh: task branch skip を確認
- scripts/release/check-pr-ready.sh 0.22.25: version mismatch で失敗することを確認
- git push: pre-push hook 通過