### PR TITLE
feat: OS追従の言語設定を追加

### DIFF
--- a/crates/katana-platform/src/os_locale.rs
+++ b/crates/katana-platform/src/os_locale.rs
@@ -28,7 +28,7 @@ impl OsLocaleOps {
     }
 
     /* WHY: Normalizes standard BCP 47 locales (e.g. en-US, zh-Hant-TW, ja-JP) into KatanA's internal subset (e.g. en, zh-TW, ja). */
-    pub(crate) fn resolve_locale_to_lang(locale: &str) -> String {
+    pub fn resolve_locale_to_lang(locale: &str) -> String {
         let lower = locale.to_lowercase();
 
         if lower.starts_with("zh-hans") || lower.contains("hans") || lower.starts_with("zh-cn") {

--- a/crates/katana-platform/src/settings.rs
+++ b/crates/katana-platform/src/settings.rs
@@ -6,7 +6,9 @@ pub mod repository;
 pub mod service;
 pub mod types;
 
-pub use defaults::{DEFAULT_IGNORED_DIRECTORIES, DEFAULT_MAX_DEPTH, SettingsDefaultOps};
+pub use defaults::{
+    AUTO_LANGUAGE_CODE, DEFAULT_IGNORED_DIRECTORIES, DEFAULT_MAX_DEPTH, SettingsDefaultOps,
+};
 pub use repository::{InMemoryRepository, JsonFileRepository, SettingsRepository};
 pub use service::SettingsService;
 pub use types::*;

--- a/crates/katana-platform/src/settings/defaults.rs
+++ b/crates/katana-platform/src/settings/defaults.rs
@@ -6,6 +6,8 @@ pub struct SettingsDefaultOps;
 pub(crate) const DEFAULT_FONT_SIZE: f32 = 14.0;
 pub(crate) const DEFAULT_AUTO_SAVE_INTERVAL_SECS: f64 = 5.0;
 pub(crate) const DEFAULT_AUTO_REFRESH_INTERVAL_SECS: f64 = 2.0;
+pub const AUTO_LANGUAGE_CODE: &str = "auto";
+pub const FALLBACK_LANGUAGE_CODE: &str = "en";
 pub const DEFAULT_MAX_DEPTH: usize = 10;
 pub const DEFAULT_CACHE_RETENTION_DAYS: u32 = 7;
 pub const DEFAULT_DIAGRAM_CONCURRENCY: usize = 10;
@@ -25,7 +27,10 @@ impl SettingsDefaultOps {
         "0.2.3".to_string()
     }
     pub fn default_language() -> String {
-        "en".to_string()
+        AUTO_LANGUAGE_CODE.to_string()
+    }
+    pub fn fallback_language() -> String {
+        FALLBACK_LANGUAGE_CODE.to_string()
     }
     pub fn default_theme() -> String {
         if crate::os_theme::OsThemeOps::is_dark_mode().unwrap_or(true) {

--- a/crates/katana-platform/src/settings/service.rs
+++ b/crates/katana-platform/src/settings/service.rs
@@ -3,7 +3,7 @@
 `SettingsService` handles reading and writing settings via the repository,
 and manages OS integration (theme, language) on first launch. */
 
-use super::defaults::SettingsDefaultOps;
+use super::defaults::{AUTO_LANGUAGE_CODE, SettingsDefaultOps};
 use super::repository::{InMemoryRepository, SettingsRepository};
 use super::types::{AppSettings, SettingsLoadOrigin};
 
@@ -54,14 +54,27 @@ impl SettingsService {
         self.settings.theme.theme = preset.colors().mode.to_theme_string();
     }
 
-    /* WHY: Applies the OS-default language on first launch. */
-    pub fn apply_os_default_language(&mut self, detected_lang: Option<String>) {
+    /* WHY: Stores auto-follow language mode on first launch. */
+    pub fn apply_os_default_language(&mut self) {
         if !self.is_first_launch {
             return;
         }
-        if let Some(lang) = detected_lang {
-            self.settings.language = lang;
+        self.settings.language = SettingsDefaultOps::default_language();
+    }
+
+    pub fn resolve_effective_language(&self, detector: impl FnOnce() -> Option<String>) -> String {
+        let saved = self.settings.language.trim();
+        if !Self::is_auto_language(saved) {
+            return saved.to_string();
         }
+
+        detector()
+            .map(|locale| crate::OsLocaleOps::resolve_locale_to_lang(&locale))
+            .unwrap_or_else(SettingsDefaultOps::fallback_language)
+    }
+
+    fn is_auto_language(language: &str) -> bool {
+        language.is_empty() || language == AUTO_LANGUAGE_CODE
     }
 
     /* WHY: Load structured workspace state (e.g. tabs, pins) from the config directory. */
@@ -128,8 +141,11 @@ mod tests {
         let mut service = SettingsService::new(repo);
         assert!(service.is_first_launch);
 
-        service.apply_os_default_language(Some("fr".to_string()));
-        assert_eq!(service.settings().language, "fr");
+        service.apply_os_default_language();
+        assert_eq!(
+            service.settings().language,
+            SettingsDefaultOps::default_language()
+        );
     }
 
     #[test]
@@ -143,7 +159,7 @@ mod tests {
 
         assert!(!service.is_first_launch);
 
-        service.apply_os_default_language(Some("fr".to_string()));
+        service.apply_os_default_language();
         /* WHY: Existing user shouldn't be overridden */
         assert_eq!(service.settings().language, "ja");
     }

--- a/crates/katana-platform/src/settings/tests/defaults_test.rs
+++ b/crates/katana-platform/src/settings/tests/defaults_test.rs
@@ -28,7 +28,7 @@ fn test_app_settings_default_values() {
     assert!(s.theme.custom_color_overrides.is_none());
     assert!((s.font.size - 14.0).abs() < f32::EPSILON);
     assert_eq!(s.font.family, "monospace");
-    assert_eq!(s.language, "en");
+    assert_eq!(s.language, AUTO_LANGUAGE_CODE);
     assert!(s.workspace.last_workspace.is_none());
     /* WHY: Behavior defaults */
     assert!(s.behavior.confirm_close_dirty_tab);

--- a/crates/katana-platform/src/settings/tests/serde_roundtrip.rs
+++ b/crates/katana-platform/src/settings/tests/serde_roundtrip.rs
@@ -74,7 +74,7 @@ fn test_app_settings_serde_missing_fields_use_defaults() {
     let loaded: AppSettings = serde_json::from_str(json).unwrap();
     assert_eq!(loaded.theme.theme, "custom");
     assert!((loaded.font.size - 14.0).abs() < f32::EPSILON);
-    assert_eq!(loaded.language, "en");
+    assert_eq!(loaded.language, AUTO_LANGUAGE_CODE);
 }
 
 #[test]

--- a/crates/katana-platform/src/settings/tests/service.rs
+++ b/crates/katana-platform/src/settings/tests/service.rs
@@ -64,23 +64,51 @@ fn test_apply_os_default_theme_on_first_launch_picks_katana_preset() {
 fn test_apply_os_default_language_is_noop_for_existing_users() {
     let mut service = SettingsService::new(Box::new(InMemoryRepository));
     service.settings_mut().language = "ja".to_string();
-    service.apply_os_default_language(Some("fr".to_string()));
+    service.apply_os_default_language();
     assert_eq!(service.settings().language, "ja");
 
-    service.apply_os_default_language(None);
+    service.apply_os_default_language();
     assert_eq!(service.settings().language, "ja");
 }
 
 #[test]
-fn test_apply_os_default_language_updates_on_first_launch() {
+fn test_apply_os_default_language_sets_auto_on_first_launch() {
     let repo = FirstLaunchRepo {
         preset: ThemePreset::KatanaDark,
     };
     let mut service = SettingsService::new(Box::new(repo));
 
-    service.apply_os_default_language(None);
-    assert_eq!(service.settings().language, "en");
+    service.apply_os_default_language();
+    assert_eq!(service.settings().language, AUTO_LANGUAGE_CODE);
+}
 
-    service.apply_os_default_language(Some("fr".to_string()));
-    assert_eq!(service.settings().language, "fr");
+#[test]
+fn test_resolve_effective_language_uses_os_locale_for_auto() {
+    let mut service = SettingsService::default();
+    service.settings_mut().language = AUTO_LANGUAGE_CODE.to_string();
+
+    assert_eq!(
+        service.resolve_effective_language(|| Some("ja-JP".to_string())),
+        "ja"
+    );
+    assert_eq!(
+        service.resolve_effective_language(|| Some("en-US".to_string())),
+        "en"
+    );
+    assert_eq!(
+        service.resolve_effective_language(|| Some("unknown".to_string())),
+        "en"
+    );
+    assert_eq!(service.resolve_effective_language(|| None), "en");
+}
+
+#[test]
+fn test_resolve_effective_language_preserves_existing_japanese_language() {
+    let mut service = SettingsService::default();
+    service.settings_mut().language = "ja".to_string();
+
+    assert_eq!(
+        service.resolve_effective_language(|| Some("en-US".to_string())),
+        "ja"
+    );
 }

--- a/crates/katana-platform/src/settings/types/app.rs
+++ b/crates/katana-platform/src/settings/types/app.rs
@@ -60,7 +60,7 @@ pub struct AppSettings {
     /* WHY: Terms of service accepted version (None = not accepted). */
     #[serde(default)]
     pub terms_accepted_version: Option<String>,
-    /* WHY: UI language ("en" or "ja", etc). */
+    /* WHY: UI language mode ("auto" or an explicit language code). */
     #[serde(default = "super::super::defaults::SettingsDefaultOps::default_language")]
     pub language: String,
     /* WHY: Additional key-value settings for future use. */

--- a/crates/katana-ui/locales/de.json
+++ b/crates/katana-ui/locales/de.json
@@ -26,6 +26,7 @@
     "demo": "Demonstrationsversion",
     "welcome_screen": "Willkommensbildschirm",
     "user_guide": "Benutzerhandbuch",
+    "language_auto": "Automatisch (Systemsprache)",
     "language_en": "Englisch",
     "language_ja": "Japanisch",
     "language_zh_cn": "Chinesisch (Vereinfacht)",

--- a/crates/katana-ui/locales/en.json
+++ b/crates/katana-ui/locales/en.json
@@ -26,6 +26,7 @@
     "demo": "Demo",
     "welcome_screen": "Welcome Screen",
     "user_guide": "User Guide",
+    "language_auto": "Auto (Follow OS)",
     "language_en": "English",
     "language_ja": "Japanese",
     "language_zh_cn": "Chinese (Simplified)",

--- a/crates/katana-ui/locales/es.json
+++ b/crates/katana-ui/locales/es.json
@@ -26,6 +26,7 @@
     "demo": "Demostración",
     "welcome_screen": "Pantalla de bienvenida",
     "user_guide": "Guía del usuario",
+    "language_auto": "Automático (seguir el sistema)",
     "language_en": "Inglés",
     "language_ja": "Japonés",
     "language_zh_cn": "Chino (Simplificado)",

--- a/crates/katana-ui/locales/fr.json
+++ b/crates/katana-ui/locales/fr.json
@@ -26,6 +26,7 @@
     "demo": "Démo",
     "welcome_screen": "Écran d'accueil",
     "user_guide": "Guide de l'utilisateur",
+    "language_auto": "Automatique (langue du système)",
     "language_en": "Anglais",
     "language_ja": "Japonais",
     "language_zh_cn": "Chinois (Simplifié)",

--- a/crates/katana-ui/locales/it.json
+++ b/crates/katana-ui/locales/it.json
@@ -26,6 +26,7 @@
     "demo": "Dimostrazione",
     "welcome_screen": "Schermata di benvenuto",
     "user_guide": "Guida utente",
+    "language_auto": "Automatico (lingua di sistema)",
     "language_en": "Inglese",
     "language_ja": "Giapponese",
     "language_zh_cn": "Cinese (Semplificato)",

--- a/crates/katana-ui/locales/ja.json
+++ b/crates/katana-ui/locales/ja.json
@@ -26,6 +26,7 @@
     "demo": "デモ・機能紹介を見る",
     "welcome_screen": "ようこそ画面",
     "user_guide": "ユーザーガイド",
+    "language_auto": "自動 (OS に追従)",
     "language_en": "英語",
     "language_ja": "日本語",
     "language_zh_cn": "中国語 (簡体字)",

--- a/crates/katana-ui/locales/ko.json
+++ b/crates/katana-ui/locales/ko.json
@@ -26,6 +26,7 @@
     "demo": "데모",
     "welcome_screen": "환영 화면",
     "user_guide": "사용자 가이드",
+    "language_auto": "자동 (OS 설정 따름)",
     "language_en": "영어",
     "language_ja": "일본어",
     "language_zh_cn": "중국어 (간체)",

--- a/crates/katana-ui/locales/pt.json
+++ b/crates/katana-ui/locales/pt.json
@@ -26,6 +26,7 @@
     "demo": "Demonstração",
     "welcome_screen": "Tela de boas-vindas",
     "user_guide": "Guia do usuário",
+    "language_auto": "Automático (acompanhar o sistema)",
     "language_en": "Inglês",
     "language_ja": "Japonês",
     "language_zh_cn": "Chinês (Simplificado)",

--- a/crates/katana-ui/locales/zh-CN.json
+++ b/crates/katana-ui/locales/zh-CN.json
@@ -26,6 +26,7 @@
     "demo": "演示",
     "welcome_screen": "欢迎屏幕",
     "user_guide": "用户指南",
+    "language_auto": "自动 (跟随系统)",
     "language_en": "英语",
     "language_ja": "日语",
     "language_zh_cn": "中文 (简体)",

--- a/crates/katana-ui/locales/zh-TW.json
+++ b/crates/katana-ui/locales/zh-TW.json
@@ -26,6 +26,7 @@
     "demo": "示範",
     "welcome_screen": "歡迎畫面",
     "user_guide": "使用指南",
+    "language_auto": "自動 (跟隨系統)",
     "language_en": "英語",
     "language_ja": "日語",
     "language_zh_cn": "中文 (簡體)",

--- a/crates/katana-ui/src/app/action/dispatch.rs
+++ b/crates/katana-ui/src/app/action/dispatch.rs
@@ -132,17 +132,6 @@ impl KatanaApp {
         }
     }
 
-    fn handle_action_change_language(&mut self, lang: String) {
-        crate::i18n::I18nOps::set_language(&lang);
-        crate::shell_ui::ShellUiOps::update_native_menu_strings_from_i18n();
-        self.state.config.settings.settings_mut().language = lang.clone();
-        if !self.state.config.try_save_settings() {
-            tracing::warn!("Failed to save language setting");
-        }
-        /* WHY: Synchronize demo content localization if the demo is open */
-        self.handle_action_switch_demo_lang(&lang);
-    }
-
     fn handle_action_close_workspace(&mut self) {
         self.save_workspace_state();
         self.state.workspace.data = None;

--- a/crates/katana-ui/src/app/action/language.rs
+++ b/crates/katana-ui/src/app/action/language.rs
@@ -1,0 +1,20 @@
+use crate::shell::KatanaApp;
+
+impl KatanaApp {
+    pub(super) fn handle_action_change_language(&mut self, lang: String) {
+        self.state.config.settings.settings_mut().language = lang;
+        let effective_language = self
+            .state
+            .config
+            .settings
+            .resolve_effective_language(katana_platform::OsLocaleOps::get_default_language);
+        crate::i18n::I18nOps::set_language(&effective_language);
+        let runtime_language = crate::i18n::I18nOps::get_language();
+        crate::shell_ui::ShellUiOps::update_native_menu_strings_from_i18n();
+        if !self.state.config.try_save_settings() {
+            tracing::warn!("Failed to save language setting");
+        }
+        /* WHY: Synchronize demo content localization if the demo is open */
+        self.handle_action_switch_demo_lang(&runtime_language);
+    }
+}

--- a/crates/katana-ui/src/app/action/mod.rs
+++ b/crates/katana-ui/src/app/action/mod.rs
@@ -9,6 +9,7 @@ mod dispatch_secondary;
 mod dispatch_tertiary;
 mod file_open;
 mod image_ingest;
+mod language;
 mod process_authoring;
 mod process_demo;
 mod process_demo_group;
@@ -116,7 +117,7 @@ impl ActionOps for KatanaApp {
                 .previous_app_version
                 .clone()
         });
-        let lang = self.state.config.settings.settings().language.clone();
+        let lang = crate::i18n::I18nOps::get_language();
         let (tx, rx) = std::sync::mpsc::channel();
         self.changelog_rx = Some(rx);
         crate::changelog::ChangelogOps::fetch_changelog(&lang, current_version, previous, tx);

--- a/crates/katana-ui/src/app/action/process_demo.rs
+++ b/crates/katana-ui/src/app/action/process_demo.rs
@@ -10,7 +10,7 @@ impl KatanaApp {
     /// Files use `Katana://Demo/` virtual paths so that auto-refresh
     /// and save operations are safely bypassed.
     pub(super) fn handle_action_open_help_demo(&mut self) {
-        let lang = self.state.config.settings.settings().language.clone();
+        let lang = crate::i18n::I18nOps::get_language();
         let demo_assets = super::demo_bundle::resolve_demo_bundle(&lang);
 
         if demo_assets.is_empty() {
@@ -24,7 +24,7 @@ impl KatanaApp {
     }
 
     pub(super) fn handle_action_open_welcome_screen(&mut self) {
-        let lang = self.state.config.settings.settings().language.clone();
+        let lang = crate::i18n::I18nOps::get_language();
         if let Some(asset) = super::demo_bundle::resolve_single_asset(&lang, "welcome.md") {
             self.open_special_virtual_asset(asset);
         }
@@ -32,7 +32,7 @@ impl KatanaApp {
 
     /// Handler for AppAction::OpenUserGuide
     pub(super) fn handle_action_open_user_guide(&mut self) {
-        let lang = self.state.config.settings.settings().language.clone();
+        let lang = crate::i18n::I18nOps::get_language();
         if let Some(asset) = super::demo_bundle::resolve_single_asset(&lang, "guide.md") {
             self.open_special_virtual_asset(asset);
         }

--- a/crates/katana-ui/src/i18n/types/menu.rs
+++ b/crates/katana-ui/src/i18n/types/menu.rs
@@ -21,6 +21,8 @@ pub struct MenuMessages {
     pub release_notes: String,
     pub view: String,
     pub command_palette: String,
+    #[serde(default = "default_menu_language_auto")]
+    pub language_auto: String,
     pub language_en: String,
     pub language_ja: String,
     pub language_zh_cn: String,
@@ -57,6 +59,10 @@ fn default_menu_zoom_in() -> String {
 
 fn default_menu_zoom_out() -> String {
     "Zoom Out".to_string()
+}
+
+fn default_menu_language_auto() -> String {
+    "Auto (Follow OS)".to_string()
 }
 
 fn default_menu_demo() -> String {

--- a/crates/katana-ui/src/language_options.rs
+++ b/crates/katana-ui/src/language_options.rs
@@ -1,0 +1,78 @@
+pub(crate) struct LanguageOption {
+    pub(crate) code: &'static str,
+    pub(crate) label: String,
+}
+
+pub(crate) struct LanguageOptionOps;
+
+impl LanguageOptionOps {
+    pub(crate) fn menu_options(i18n: &crate::i18n::I18nMessages) -> Vec<LanguageOption> {
+        vec![
+            Self::option(
+                katana_platform::settings::AUTO_LANGUAGE_CODE,
+                &i18n.menu.language_auto,
+            ),
+            Self::option("en", &i18n.menu.language_en),
+            Self::option("ja", &i18n.menu.language_ja),
+            Self::option("zh-CN", &i18n.menu.language_zh_cn),
+            Self::option("zh-TW", &i18n.menu.language_zh_tw),
+            Self::option("ko", &i18n.menu.language_ko),
+            Self::option("pt", &i18n.menu.language_pt),
+            Self::option("fr", &i18n.menu.language_fr),
+            Self::option("de", &i18n.menu.language_de),
+            Self::option("es", &i18n.menu.language_es),
+            Self::option("it", &i18n.menu.language_it),
+        ]
+    }
+
+    pub(crate) fn label_for(code: &str, i18n: &crate::i18n::I18nMessages) -> String {
+        Self::menu_options(i18n)
+            .into_iter()
+            .find(|it| it.code == code)
+            .map(|it| it.label)
+            .unwrap_or_else(|| code.to_string())
+    }
+
+    fn option(code: &'static str, label: &str) -> LanguageOption {
+        LanguageOption {
+            code,
+            label: label.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn menu_options_puts_auto_language_first() {
+        let i18n = crate::i18n::I18nOps::get();
+
+        let options = LanguageOptionOps::menu_options(i18n);
+
+        assert_eq!(
+            options.first().map(|it| it.code),
+            Some(katana_platform::settings::AUTO_LANGUAGE_CODE)
+        );
+        assert_eq!(
+            options.first().map(|it| it.label.as_str()),
+            Some(i18n.menu.language_auto.as_str())
+        );
+        assert_eq!(options.len(), 11);
+    }
+
+    #[test]
+    fn label_for_resolves_known_code_and_keeps_unknown_code() {
+        let i18n = crate::i18n::I18nOps::get();
+
+        assert_eq!(
+            LanguageOptionOps::label_for("ja", i18n),
+            i18n.menu.language_ja
+        );
+        assert_eq!(
+            LanguageOptionOps::label_for("custom-lang", i18n),
+            "custom-lang"
+        );
+    }
+}

--- a/crates/katana-ui/src/lib.rs
+++ b/crates/katana-ui/src/lib.rs
@@ -22,6 +22,7 @@ pub mod html_renderer;
 pub(crate) mod http_cache_loader;
 pub mod i18n;
 pub mod icon;
+pub(crate) mod language_options;
 pub mod lint_fix_batch;
 pub(crate) mod linter_bridge;
 pub(crate) mod linter_config_bridge;

--- a/crates/katana-ui/src/macos_menu.m
+++ b/crates/katana-ui/src/macos_menu.m
@@ -9,6 +9,7 @@ enum {
     TAG_OPEN_WORKSPACE = 1,
     TAG_SAVE           = 2,
     TAG_OPEN_FILE      = 21,
+    TAG_LANG_AUTO      = 38,
     TAG_LANG_EN        = 3,
     TAG_LANG_JA        = 4,
     TAG_ABOUT          = 5,
@@ -473,6 +474,14 @@ void katana_setup_native_menu(void) {
     /* WHY: --- Settings > Language --- */
     NSMenu *langMenu = [[NSMenu alloc] initWithTitle:@"Language"];
     g_language_menu = langMenu;
+
+    NSMenuItem *autoItem = [[NSMenuItem alloc]
+        initWithTitle:@"Auto"
+        action:action
+        keyEquivalent:@""];
+    [autoItem setTarget:g_target];
+    [autoItem setTag:TAG_LANG_AUTO];
+    [langMenu addItem:autoItem];
 
     NSMenuItem *enItem = [[NSMenuItem alloc]
         initWithTitle:@"English"

--- a/crates/katana-ui/src/main.rs
+++ b/crates/katana-ui/src/main.rs
@@ -55,9 +55,10 @@ fn main() -> eframe::Result<()> {
     let mut settings = SettingsService::new(Box::new(repo));
 
     settings.apply_os_default_theme();
-    settings.apply_os_default_language(katana_platform::OsLocaleOps::get_default_language());
+    settings.apply_os_default_language();
 
-    let saved_language = settings.settings().language.clone();
+    let runtime_language =
+        settings.resolve_effective_language(katana_platform::OsLocaleOps::get_default_language);
     let saved_icon_pack = settings.settings().theme.icon_pack.clone();
     let saved_icon_settings = settings.settings().icon.clone();
 
@@ -98,7 +99,7 @@ fn main() -> eframe::Result<()> {
                 );
             }
 
-            katana_ui::i18n::I18nOps::set_language(&saved_language);
+            katana_ui::i18n::I18nOps::set_language(&runtime_language);
             katana_ui::shell_ui::ShellUiOps::update_native_menu_strings_from_i18n();
 
             let mut app = KatanaApp::new(state);

--- a/crates/katana-ui/src/native_menu/mod.rs
+++ b/crates/katana-ui/src/native_menu/mod.rs
@@ -6,6 +6,7 @@ mod ffi {
     pub const TAG_OPEN_WORKSPACE: i32 = 1;
     pub const TAG_SAVE: i32 = 2;
     pub const TAG_OPEN_FILE: i32 = 21;
+    pub const TAG_LANG_AUTO: i32 = 38;
     pub const TAG_LANG_EN: i32 = 3;
     pub const TAG_LANG_JA: i32 = 4;
     pub const TAG_ABOUT: i32 = 5;
@@ -139,6 +140,9 @@ impl NativeMenuOps {
             ffi::TAG_OPEN_WORKSPACE => AppAction::PickOpenWorkspace,
             ffi::TAG_OPEN_FILE => AppAction::PickOpenFileInCurrentWorkspace,
             ffi::TAG_SAVE => AppAction::SaveDocument,
+            ffi::TAG_LANG_AUTO => {
+                AppAction::ChangeLanguage(katana_platform::settings::AUTO_LANGUAGE_CODE.to_string())
+            }
             ffi::TAG_LANG_EN => AppAction::ChangeLanguage("en".to_string()),
             ffi::TAG_LANG_JA => AppAction::ChangeLanguage("ja".to_string()),
             ffi::TAG_LANG_ZH_CN => AppAction::ChangeLanguage("zh-CN".to_string()),

--- a/crates/katana-ui/src/settings/tabs/behavior/general.rs
+++ b/crates/katana-ui/src/settings/tabs/behavior/general.rs
@@ -1,0 +1,52 @@
+use crate::app_state::{AppAction, AppState};
+use crate::settings::*;
+use eframe::egui;
+
+pub struct BehaviorGeneralOps;
+
+impl BehaviorGeneralOps {
+    pub(super) fn render(ui: &mut egui::Ui, state: &mut AppState) -> Option<AppAction> {
+        let i18n = crate::i18n::I18nOps::get();
+        ui.label(egui::RichText::new(&i18n.settings.general).strong());
+        ui.add_space(SETTINGS_TOGGLE_SPACING);
+
+        let current = state.config.settings.settings().language.clone();
+        let selected = crate::language_options::LanguageOptionOps::label_for(&current, i18n);
+        let mut action = None;
+
+        ui.indent("behavior_general_settings_body", |ui| {
+            crate::widgets::AlignCenter::new()
+                .left(|ui| ui.label(&i18n.menu.language))
+                .right(|ui| {
+                    egui::ComboBox::from_id_salt("settings_language_selector")
+                        .selected_text(selected)
+                        .width(LANGUAGE_SELECTOR_WIDTH)
+                        .show_ui(ui, |ui| {
+                            for option in
+                                crate::language_options::LanguageOptionOps::menu_options(i18n)
+                            {
+                                if ui
+                                    .add(
+                                        egui::Button::selectable(
+                                            current == option.code,
+                                            option.label,
+                                        )
+                                        .frame_when_inactive(true),
+                                    )
+                                    .clicked()
+                                {
+                                    action =
+                                        Some(AppAction::ChangeLanguage(option.code.to_string()));
+                                }
+                            }
+                        })
+                        .response
+                })
+                .show(ui);
+        });
+
+        action
+    }
+}
+
+const LANGUAGE_SELECTOR_WIDTH: f32 = 240.0;

--- a/crates/katana-ui/src/settings/tabs/behavior/mod.rs
+++ b/crates/katana-ui/src/settings/tabs/behavior/mod.rs
@@ -4,6 +4,7 @@ use crate::settings::*;
 
 mod diff_mode;
 mod editor;
+mod general;
 mod ingest;
 mod performance;
 
@@ -13,6 +14,11 @@ impl BehaviorTabOps {
         state: &mut crate::app_state::AppState,
     ) -> Option<AppAction> {
         let behavior_msgs = &crate::i18n::I18nOps::get().settings.behavior;
+        if let Some(action) = general::BehaviorGeneralOps::render(ui, state) {
+            return Some(action);
+        }
+        ui.add_space(SUBSECTION_SPACING);
+
         ui.label(egui::RichText::new(&behavior_msgs.editor_behavior_section_title).strong());
         ui.add_space(SETTINGS_TOGGLE_SPACING);
         ui.indent("behavior_editor_settings_body", |ui| {

--- a/crates/katana-ui/src/views/app_frame/global_menu_context.rs
+++ b/crates/katana-ui/src/views/app_frame/global_menu_context.rs
@@ -79,7 +79,6 @@ impl<'a> GlobalMenuContext<'a> {
     }
 
     fn is_language_selected(&self, current: &str, code: &str) -> bool {
-        let default = katana_platform::OsLocaleOps::get_default_language();
-        current == code || (current.is_empty() && default.as_deref() == Some(code))
+        current == code
     }
 }

--- a/crates/katana-ui/src/views/app_frame/global_menu_settings.rs
+++ b/crates/katana-ui/src/views/app_frame/global_menu_settings.rs
@@ -23,28 +23,9 @@ impl GlobalSettingsMenu {
     fn render_language_menu(ui: &mut egui::Ui, context: &mut GlobalMenuContext<'_>) {
         let menu_label = context.i18n().menu.language.clone();
         crate::widgets::MenuButtonOps::show(ui, &menu_label, |ui| {
-            for (code, label) in Self::language_options(context) {
-                context.select_language(ui, code, &label);
+            for option in crate::language_options::LanguageOptionOps::menu_options(context.i18n()) {
+                context.select_language(ui, option.code, &option.label);
             }
         });
     }
-
-    fn language_options(
-        context: &GlobalMenuContext<'_>,
-    ) -> [(&'static str, String); LANGUAGE_OPTION_COUNT] {
-        [
-            ("en", context.i18n().menu.language_en.clone()),
-            ("ja", context.i18n().menu.language_ja.clone()),
-            ("zh-CN", context.i18n().menu.language_zh_cn.clone()),
-            ("zh-TW", context.i18n().menu.language_zh_tw.clone()),
-            ("ko", context.i18n().menu.language_ko.clone()),
-            ("pt", context.i18n().menu.language_pt.clone()),
-            ("fr", context.i18n().menu.language_fr.clone()),
-            ("de", context.i18n().menu.language_de.clone()),
-            ("es", context.i18n().menu.language_es.clone()),
-            ("it", context.i18n().menu.language_it.clone()),
-        ]
-    }
 }
-
-const LANGUAGE_OPTION_COUNT: usize = 10;

--- a/openspec/changes/v0-22-25-update-dialog-i18n-and-release-ci-integrity/tasks.md
+++ b/openspec/changes/v0-22-25-update-dialog-i18n-and-release-ci-integrity/tasks.md
@@ -62,13 +62,24 @@ D. 更新確認 dialog の error 詳細部分が i18n 化されておらず、`u
 
 ### C. OS-follow locale mode
 
-- [ ] C-1. `SettingsDefaultOps::default_language` を `"en"` → `"auto"` に変更。
-- [ ] C-2. `SettingsService::resolve_effective_language(detector: impl FnOnce() -> Option<String>) -> String` を新設。"auto" → OS locale → "en" の優先順位で評価する。
-- [ ] C-3. `apply_os_default_language` を「first_launch 時に保存値を `"auto"` にする」だけに簡素化。OS 言語の即時保存は行わない。
-- [ ] C-4. 全 caller を `resolve_effective_language` 経由に切り替え (`global_menu_context.rs`, i18n bundle ロード経路, 等)。
-- [ ] C-5. 設定 UI (`crates/katana-ui/src/settings/tabs/general.rs` 付近) の Language dropdown 先頭に "Auto" を追加。各 locale JSON に label を追加。
-- [ ] C-6. Migration test: 既存 `language: "ja"` の repository が `resolve_effective_language` で `"ja"` を返すこと (沈黙の置換が起きないこと) を保証。
-- [ ] C-7. "auto" + OS locale が `ja-JP`/`en-US`/unknown の 3 ケースで期待値を返すユニットテスト。
+- [x] C-1. `SettingsDefaultOps::default_language` を `"en"` → `"auto"` に変更。
+- [x] C-2. `SettingsService::resolve_effective_language(detector: impl FnOnce() -> Option<String>) -> String` を新設。"auto" → OS locale → "en" の優先順位で評価する。
+- [x] C-3. `apply_os_default_language` を「first_launch 時に保存値を `"auto"` にする」だけに簡素化。OS 言語の即時保存は行わない。
+- [x] C-4. 全 caller を `resolve_effective_language` 経由に切り替え (`global_menu_context.rs`, i18n bundle ロード経路, 等)。
+- [x] C-5. 設定 UI (`crates/katana-ui/src/settings/tabs/general.rs` 付近) の Language dropdown 先頭に "Auto" を追加。各 locale JSON に label を追加。
+- [x] C-6. Migration test: 既存 `language: "ja"` の repository が `resolve_effective_language` で `"ja"` を返すこと (沈黙の置換が起きないこと) を保証。
+- [x] C-7. "auto" + OS locale が `ja-JP`/`en-US`/unknown の 3 ケースで期待値を返すユニットテスト。
+
+#### C verification
+
+- [x] `cargo test -p katana-platform settings` が通過。
+- [x] `cargo test -p katana-platform test_resolve_effective_language --lib` が通過。
+- [x] `cargo test -p katana-platform test_apply_os_default_language --lib` が通過。
+- [x] `cargo check -p katana-ui` が通過。
+- [x] `cargo test -p katana-ui all_locale_files_deserialize_to_strong_struct` が通過。
+- [x] `cargo test -p katana-ui test_persistence_language_roundtrip` が通過。
+- [x] `cargo test -p katana-ui i18n::logic::tests::set_language_with_unknown_code_does_not_panic --lib -- --test-threads=1` が通過。
+- [x] `cargo clippy -p katana-platform -p katana-ui --lib -- -D warnings` が通過。
 
 ### D. Update-check error i18n
 


### PR DESCRIPTION
## 概要
- 言語設定の保存値に auto を追加し、初回起動時の既定値を OS 追従に変更
- 起動時と言語変更時に OS 言語から実際の表示言語を解決
- 設定画面とメニューに「自動（OS に追従）」を追加

## 確認
- just check-local
- scripts/release/check-pr-ready.sh
- scripts/release/check-pr-ready.sh 0.22.25 は現時点では Cargo.toml が v0.22.24 のため想定通り失敗
