### PR TITLE
fix: リリースpreflightにGitHub tokenを渡す

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -146,6 +146,8 @@ jobs:
           echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Run release preflight logic
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: ./scripts/release/check-pr-ready.sh "${{ steps.version.outputs.version_bare }}"
 
       - name: Extract release notes from CHANGELOG.md


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要 (Overview)

v0.22.33 の release workflow が `check-pr-ready.sh` 実行時に GitHub API 認証情報を受け取れず失敗する問題を修正します。

## 対応内容 (Changes Made)

- `Run release preflight logic` step に `GH_TOKEN: ${{ github.token }}` を設定
- 既存の release guard と PR ready 判定は変更せず、そのまま認証付きで実行

## 影響範囲 (Impact Scope)

- `.github/workflows/build-and-release.yml` の release preflight step のみ
- KatanA 本体、KRR/KDV、coverage 閾値、release target policy への変更なし

## 動作確認結果 (Verification Results)

- workflow YAML parse 成功
- `GITHUB_ACTIONS=true` で `scripts/release/check-pr-ready.sh 0.22.33` 成功
- release preflight / version increment / release target guard 成功
- normal pre-push hook 成功（macOS / Linux）
- 直前の HTML headless acceptance 60/60 成功
- approved screenshots 11枚との pixel comparison: AE=0 / RMSE=0

## Release policy

- release target は v0.22.33 のみ
- v0.29.0 は再リリースしない
- publish は本 PR の全必須チェック成功後に release workflow で実行する