### PR TITLE
fix: cargo-bundleのrelease導入経路を修正

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -193,10 +193,8 @@ jobs:
             ${{ runner.os }}-cargo-release-
 
       - name: Install cargo-bundle
-        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
-        with:
-          tool: cargo-bundle@0.11.0
-          fallback: none
+        # WHY: install-action v2.85.7 does not support cargo-bundle 0.11.0.
+        run: cargo install cargo-bundle --version 0.11.0 --locked
       - name: Install DMG tooling
         run: brew install create-dmg
       - name: Clean stale DMG files

--- a/scripts/release/check-multi-format-document-contract.py
+++ b/scripts/release/check-multi-format-document-contract.py
@@ -466,6 +466,7 @@ def verify(root: Path, target_version: str) -> None:
         (
             "taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60",
             "tool: cargo-deny@0.20.2",
+            "cargo install cargo-bundle --version 0.11.0 --locked",
         ),
     )
     print("OK: KatanA multi-format document ownership and release contract is satisfied.")


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
v0.22.38 Release workflowのmacOS buildが、taiki-e/install-actionで未対応のcargo-bundle 0.11.0を指定して失敗する問題を修正します。

## 対応内容
- cargo-bundle 0.11.0をCargoの固定versionインストールへ変更
- multi-format release contractに固定インストール経路の回帰検査を追加

## 影響範囲
- macOS release packaging workflowのみ
- coverage、asset contract、KDV/KRR境界、アプリ実装への変更なし

## 動作確認結果
- multi-format contract self-test: pass
- multi-format contract live check v0.22.38: pass
- strict release preflight v0.22.38: pass

## 失敗証跡
- Release run 31526391663 / Build macOS
- 原因: install-action v2.85.7がcargo-bundle 0.11.0を未対応として拒否