### PR TITLE
docs: v0.22.39の公開証跡を記録する

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -42,4 +42,8 @@ jobs:
             version="$(cat Cargo.toml | awk -F'\"' '/^version = / {print $2}')"
           fi
 
-          ./scripts/release/check-pr-ready.sh "$version" --pr-bootstrap
+          if [[ "${GITHUB_HEAD_REF}" == docs/v*-public-release-evidence ]]; then
+            ./scripts/release/check-pr-ready.sh "$version" --post-release-evidence
+          else
+            ./scripts/release/check-pr-ready.sh "$version" --pr-bootstrap
+          fi

--- a/crates/katana-ui/src/preview_pane/image_background.rs
+++ b/crates/katana-ui/src/preview_pane/image_background.rs
@@ -30,7 +30,8 @@ impl ImageBackgroundOps {
     }
 
     pub(super) fn composite_rgba_over_background(rgba: &mut [u8], background: egui::Color32) {
-        for pixel in rgba.chunks_exact_mut(RGBA_CHANNELS) {
+        let (pixels, _) = rgba.as_chunks_mut::<RGBA_CHANNELS>();
+        for pixel in pixels {
             let alpha = pixel[ALPHA_CHANNEL_INDEX];
             if alpha == u8::MAX {
                 continue;
@@ -92,6 +93,24 @@ mod tests {
                 30,
                 255
             ]
+        );
+    }
+
+    #[test]
+    fn composite_rgba_preserves_incomplete_trailing_components() {
+        let mut rgba = vec![255, 0, 0, 0, 7, 8];
+        let background = crate::theme_bridge::ThemeBridgeOps::rgb_to_color32(
+            katana_platform::theme::ThemePreset::SolarizedLight
+                .colors()
+                .preview
+                .background,
+        );
+
+        ImageBackgroundOps::composite_rgba_over_background(&mut rgba, background);
+
+        assert_eq!(
+            rgba,
+            vec![background.r(), background.g(), background.b(), 255, 7, 8]
         );
     }
 }

--- a/crates/katana-ui/src/preview_pane/image_html_surface.rs
+++ b/crates/katana-ui/src/preview_pane/image_html_surface.rs
@@ -386,6 +386,14 @@ mod tests {
 
         assert_eq!(surface.frame_matching_rgb_pixels([232, 199, 255]), Some(1));
         assert_eq!(surface.frame_matching_rgb_pixels([1, 2, 3]), Some(0));
+        surface.frame = Some(BrowserFrame::new(
+            2,
+            viewport,
+            0.0,
+            1.0,
+            vec![232, 199, 255, 255, 7, 8],
+        ));
+        assert_eq!(surface.frame_matching_rgb_pixels([232, 199, 255]), Some(1));
         surface.frame = None;
         assert_eq!(surface.frame_matching_rgb_pixels([232, 199, 255]), None);
     }

--- a/crates/katana-ui/src/preview_pane/image_html_surface_pane.rs
+++ b/crates/katana-ui/src/preview_pane/image_html_surface_pane.rs
@@ -23,7 +23,9 @@ impl HtmlBrowserSurface {
         self.frame.as_ref().map(|frame| {
             frame
                 .pixels
-                .chunks_exact(RGBA_COMPONENT_COUNT)
+                .as_chunks::<RGBA_COMPONENT_COUNT>()
+                .0
+                .iter()
                 .filter(|pixel| {
                     pixel[0] == expected[0]
                         && pixel[1] == expected[1]

--- a/openspec/changes/v0-22-39-office2pdf-official-intake/evidence/release-evaluation.json
+++ b/openspec/changes/v0-22-39-office2pdf-official-intake/evidence/release-evaluation.json
@@ -80,5 +80,22 @@
       "windows_screenshots": 13,
       "windows_pptx_visual_review": "pass; Japanese glyphs, shapes, and page navigation are visible"
     }
+  },
+  "public_release_evidence": {
+    "release": "https://github.com/HiroyukiFuruno/KatanA/releases/tag/v0.22.39",
+    "release_workflow": "https://github.com/HiroyukiFuruno/KatanA/actions/runs/32395530635",
+    "tag_target": "0cb04823ef6beb96c4bb12d9f11108fad62c1b22",
+    "status": "published; not draft; not prerelease",
+    "checksums_asset_sha256": "90a0c89f5ba692523b93f461848ba4c8c6d9102736bfd78d111d6f43753c65c8",
+    "assets": {
+      "KatanA-Desktop-0.22.39.dmg": "5ca431587c709475513e8b63c12ab25954a05a15748ff5f97b8a5b42c84acdbd",
+      "KatanA-linux-x86_64.tar.gz": "59cef6a1a0fbdf83f3afdc9e127a5c29402eedf948642416748812a06bf8b5c5",
+      "KatanA-macOS.zip": "ce93ef07d6903b2d3df0f4a73515f7ec0e5d8b5d83a39bc9b2b5f99cb7479e72",
+      "KatanA-windows-x86_64.msi": "24944c011d569f3485599cacfcaa2e3dbf60db080c24843a0c8065538f10ba24",
+      "KatanA-windows-x86_64.zip": "30145ed68aea57726157a14257b54d9806af8493e85ef9439ca922842918e80b"
+    },
+    "checksum_verification": "downloaded public checksums.txt and matched its digest plus every published asset digest",
+    "attestation": "published by the successful release workflow",
+    "automation": "office2pdf deleted after public artifact verification"
   }
 }

--- a/openspec/changes/v0-22-39-office2pdf-official-intake/tasks.md
+++ b/openspec/changes/v0-22-39-office2pdf-official-intake/tasks.md
@@ -18,4 +18,4 @@
 
 ## 4. Release
 
-- [ ] 4.1 verified evidence を記録し、既存の明示承認に従って commit、push、PR、merge、v0.22.39 release、public artifact verification、automation removal を順に実行する
+- [x] 4.1 verified evidence を記録し、既存の明示承認に従って commit、push、PR、merge、v0.22.39 release、public artifact verification、automation removal を順に実行する

--- a/scripts/release/check-multi-format-document-contract.py
+++ b/scripts/release/check-multi-format-document-contract.py
@@ -476,7 +476,12 @@ def verify(root: Path, target_version: str) -> None:
             "taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60",
             "tool: cargo-deny@0.20.2",
             'check-pr-ready.sh "$version" --pr-bootstrap',
+            "docs/v*-public-release-evidence",
         ),
+    )
+    require_markers(
+        root / "scripts/release/check-pr-ready.sh",
+        ("--post-release-evidence", "Published stable GitHub Release"),
     )
     require_markers(
         root / ".github/workflows/build-and-release.yml",

--- a/scripts/release/check-pr-ready.sh
+++ b/scripts/release/check-pr-ready.sh
@@ -23,6 +23,7 @@ for argument in "$@"; do
     case "$argument" in
         --pr-bootstrap) TASK_GATE_MODE="pr-bootstrap" ;;
         --release-artifact-pending) TASK_GATE_MODE="release-artifact-pending" ;;
+        --post-release-evidence) TASK_GATE_MODE="post-release-evidence" ;;
         --*) error "Unknown option: $argument"; exit 2 ;;
         *)
             if [[ -n "$EXPECTED_VERSION" ]]; then
@@ -129,10 +130,25 @@ fi
 rm -f "$LOCK_CHECK_OUTPUT"
 success "Cargo.lock is synced."
 
-# 5. Version increment guard
-if ! ./scripts/release/check-version-increment.sh "$TARGET_VERSION"; then
-    error "Version increment check failed for v${TARGET_VERSION}."
-    exit 1
+# 5. Version increment or published-release guard
+if [[ "$TASK_GATE_MODE" == "post-release-evidence" ]]; then
+    RELEASE_STATE=$(gh release view "v${TARGET_VERSION}" \
+        --repo "${KATANA_RELEASE_REPO:-HiroyukiFuruno/KatanA}" \
+        --json tagName,isDraft,isPrerelease \
+        --jq '.tagName + " draft=" + (.isDraft | tostring) + " prerelease=" + (.isPrerelease | tostring)' 2>/dev/null) || {
+        error "Published GitHub Release v${TARGET_VERSION} is required for post-release evidence."
+        exit 1
+    }
+    if [[ "$RELEASE_STATE" != "v${TARGET_VERSION} draft=false prerelease=false" ]]; then
+        error "v${TARGET_VERSION} is not a published stable GitHub Release: ${RELEASE_STATE}"
+        exit 1
+    fi
+    success "Published stable GitHub Release v${TARGET_VERSION} is present."
+else
+    if ! ./scripts/release/check-version-increment.sh "$TARGET_VERSION"; then
+        error "Version increment check failed for v${TARGET_VERSION}."
+        exit 1
+    fi
 fi
 
 # 6. Branch naming vs Target Version for Release branches

--- a/scripts/release/preflight.sh
+++ b/scripts/release/preflight.sh
@@ -134,6 +134,9 @@ for CHANGE_DIR in openspec/changes/v${VERSION_DASHED}-*(N); do
             elif [[ "$TASK_GATE_MODE" == "release-artifact-pending" && "$CHANGE_NAME" == "v0-22-39-office2pdf-official-intake" ]]; then
                 # Public release verification can only run after GitHub publishes assets.
                 TASK_GATE_ARGS=(--allow 4.1)
+            elif [[ "$TASK_GATE_MODE" == "post-release-evidence" && "$CHANGE_NAME" == "v0-22-39-office2pdf-official-intake" ]]; then
+                # The post-release evidence change must have no incomplete OpenSpec tasks.
+                TASK_GATE_ARGS=()
             elif [[ "$TASK_GATE_MODE" != "strict" ]]; then
                 error "Unsupported OpenSpec task gate mode: $TASK_GATE_MODE"
                 exit 2


### PR DESCRIPTION
## Summary
- v0.22.39 の GitHub Release、tag、checksums、asset digest を記録
- 公開済み version の evidence-only PR を通常の次版 SemVer gate と分離
- 完了した OpenSpec task 4.1 と監視 automation 削除を記録

## Verification
- `python3 scripts/release/check-multi-format-document-contract.py --self-test`
- `python3 scripts/release/check-multi-format-document-contract.py 0.22.39`
- `./scripts/release/check-pr-ready.sh 0.22.39 --post-release-evidence`