### PR TITLE
fix: 非操作図のテクスチャを保持する

### DIFF
--- a/crates/katana-ui/src/preview_pane/document_surface/worker_tests.rs
+++ b/crates/katana-ui/src/preview_pane/document_surface/worker_tests.rs
@@ -42,6 +42,7 @@ fn test_frame() -> DocumentFrame {
         capabilities: ViewerCapabilities::static_page(),
         diagnostics: Vec::new(),
         format: ViewerDocumentFormat::Pdf,
+        spreadsheet: None,
     }
 }
 

--- a/crates/katana-ui/src/preview_pane/image_raster.rs
+++ b/crates/katana-ui/src/preview_pane/image_raster.rs
@@ -64,6 +64,7 @@ impl ImageLogicOps {
         alt_text: &str,
         idx: usize,
         mut state: Option<&mut ViewerState>,
+        interaction_enabled: bool,
         fullscreen_request: Option<&mut Option<usize>>,
         draw_background: impl FnOnce(&mut egui::Ui, egui::Rect, bool),
     ) -> egui::Rect {
@@ -85,7 +86,8 @@ impl ImageLogicOps {
             state.prepare_texture(ViewerTextureIdentity::rasterized(img), preview_background);
         }
 
-        if let Some(state) = state.as_mut()
+        if interaction_enabled
+            && let Some(state) = state.as_mut()
             && response.hovered()
         {
             let zoom_delta = ui.input(|i| i.zoom_delta());
@@ -142,7 +144,7 @@ impl ImageLogicOps {
 
         draw_background(ui, container_rect, response.hovered());
 
-        if let Some(state) = state {
+        if interaction_enabled && let Some(state) = state {
             if crate::diagram_controller::DiagramControllerOps::draw_fullscreen_button(
                 ui,
                 container_rect,

--- a/crates/katana-ui/src/preview_pane/image_raster.rs
+++ b/crates/katana-ui/src/preview_pane/image_raster.rs
@@ -8,6 +8,12 @@ use super::types::ImageLogicOps;
 pub(super) const MIN_ZOOM: f32 = 0.1;
 pub(super) const MAX_ZOOM: f32 = 10.0;
 
+pub(crate) struct RasterizedImageOptions<'a> {
+    pub state: Option<&'a mut ViewerState>,
+    pub interaction_enabled: bool,
+    pub fullscreen_request: Option<&'a mut Option<usize>>,
+}
+
 /// WHY: Minimum container height to prevent the 3×3 control grid and fullscreen
 /// button from overlapping on diagrams with a small rendered height.
 const MIN_CONTAINER_HEIGHT: f32 = 145.0;
@@ -63,9 +69,7 @@ impl ImageLogicOps {
         img: &RasterizedSvg,
         alt_text: &str,
         idx: usize,
-        mut state: Option<&mut ViewerState>,
-        interaction_enabled: bool,
-        fullscreen_request: Option<&mut Option<usize>>,
+        mut options: RasterizedImageOptions<'_>,
         draw_background: impl FnOnce(&mut egui::Ui, egui::Rect, bool),
     ) -> egui::Rect {
         let max_w = ui.available_width();
@@ -82,12 +86,12 @@ impl ImageLogicOps {
             ui.visuals().window_fill(),
         );
 
-        if let Some(state) = state.as_mut() {
+        if let Some(state) = options.state.as_mut() {
             state.prepare_texture(ViewerTextureIdentity::rasterized(img), preview_background);
         }
 
-        if interaction_enabled
-            && let Some(state) = state.as_mut()
+        if options.interaction_enabled
+            && let Some(state) = options.state.as_mut()
             && response.hovered()
         {
             let zoom_delta = ui.input(|i| i.zoom_delta());
@@ -99,11 +103,11 @@ impl ImageLogicOps {
             }
         }
 
-        let zoom = state.as_ref().map_or(1.0, |s| s.zoom);
-        let pan = state.as_ref().map_or(egui::Vec2::ZERO, |s| s.pan);
+        let zoom = options.state.as_ref().map_or(1.0, |s| s.zoom);
+        let pan = options.state.as_ref().map_or(egui::Vec2::ZERO, |s| s.pan);
         let zoomed_size = base_size * zoom;
 
-        let texture_handle = if let Some(state) = state.as_mut() {
+        let texture_handle = if let Some(state) = options.state.as_mut() {
             if state.texture.is_none() || state.texture_background != Some(preview_background) {
                 let color_img = color_image_for_texture(
                     img,
@@ -144,11 +148,13 @@ impl ImageLogicOps {
 
         draw_background(ui, container_rect, response.hovered());
 
-        if interaction_enabled && let Some(state) = state {
+        if options.interaction_enabled
+            && let Some(state) = options.state
+        {
             if crate::diagram_controller::DiagramControllerOps::draw_fullscreen_button(
                 ui,
                 container_rect,
-            ) && let Some(req) = fullscreen_request
+            ) && let Some(req) = options.fullscreen_request
             {
                 *req = Some(idx);
             }

--- a/crates/katana-ui/src/preview_pane/section_images.rs
+++ b/crates/katana-ui/src/preview_pane/section_images.rs
@@ -49,12 +49,14 @@ impl SectionImageOps {
             svg_data,
             alt,
             i,
-            state,
-            allow_controls,
-            if !allow_controls {
-                None
-            } else {
-                fullscreen_request
+            crate::preview_pane::image_raster::RasterizedImageOptions {
+                state,
+                interaction_enabled: allow_controls,
+                fullscreen_request: if !allow_controls {
+                    None
+                } else {
+                    fullscreen_request
+                },
             },
             |ui, rect, is_hovered| {
                 if allow_hover && (is_hovered || is_active) {

--- a/crates/katana-ui/src/preview_pane/section_images.rs
+++ b/crates/katana-ui/src/preview_pane/section_images.rs
@@ -30,17 +30,14 @@ impl SectionImageOps {
                     .unwrap_or(false)
             });
 
-        /* WHY: In slideshow mode diagrams are read-only; controls and hover highlight are hidden by default */
-        let state = if !allow_controls {
-            None
-        } else {
-            viewer_states.map(|vs| {
-                if vs.len() <= i {
-                    vs.resize_with(i + 1, crate::preview_pane::ViewerState::default);
-                }
-                &mut vs[i]
-            })
-        };
+        /* WHY: controls may be hidden for capture, but the texture handle must survive the
+         * pass so egui can upload and render the diagram on the next frame. */
+        let state = viewer_states.map(|vs| {
+            if vs.len() <= i {
+                vs.resize_with(i + 1, crate::preview_pane::ViewerState::default);
+            }
+            &mut vs[i]
+        });
 
         let is_active = !is_slideshow
             && active_editor_line.is_some_and(|line| {
@@ -53,6 +50,7 @@ impl SectionImageOps {
             alt,
             i,
             state,
+            allow_controls,
             if !allow_controls {
                 None
             } else {

--- a/crates/katana-ui/src/preview_pane/section_show/mod.rs
+++ b/crates/katana-ui/src/preview_pane/section_show/mod.rs
@@ -54,9 +54,11 @@ pub(super) fn show_section(
                 svg_data,
                 alt,
                 id,
-                None,
-                false,
-                None,
+                crate::preview_pane::image_raster::RasterizedImageOptions {
+                    state: None,
+                    interaction_enabled: false,
+                    fullscreen_request: None,
+                },
                 |_, _, _| {},
             );
             vec![]

--- a/crates/katana-ui/src/preview_pane/section_show/mod.rs
+++ b/crates/katana-ui/src/preview_pane/section_show/mod.rs
@@ -55,6 +55,7 @@ pub(super) fn show_section(
                 alt,
                 id,
                 None,
+                false,
                 None,
                 |_, _, _| {},
             );

--- a/crates/katana-ui/src/preview_pane/tests.rs
+++ b/crates/katana-ui/src/preview_pane/tests.rs
@@ -82,9 +82,11 @@ mod tests {
                         image,
                         "Mermaid diagram",
                         0,
-                        Some(state),
-                        true,
-                        None,
+                        crate::preview_pane::image_raster::RasterizedImageOptions {
+                            state: Some(state),
+                            interaction_enabled: true,
+                            fullscreen_request: None,
+                        },
                         |_, _, _| {},
                     );
                 });

--- a/crates/katana-ui/src/preview_pane/tests.rs
+++ b/crates/katana-ui/src/preview_pane/tests.rs
@@ -83,8 +83,50 @@ mod tests {
                         "Mermaid diagram",
                         0,
                         Some(state),
+                        true,
                         None,
                         |_, _, _| {},
+                    );
+                });
+            },
+        );
+    }
+
+    fn render_controls_hidden_rasterized_image(
+        ctx: &egui::Context,
+        states: &mut Vec<ViewerState>,
+        image: &katana_core::markdown::svg_rasterize::RasterizedSvg,
+    ) {
+        crate::test_ui::TestUiOps::run(
+            ctx,
+            egui::RawInput {
+                screen_rect: Some(egui::Rect::from_min_size(
+                    egui::pos2(0.0, 0.0),
+                    egui::vec2(800.0, 600.0),
+                )),
+                ..Default::default()
+            },
+            |ctx| {
+                ctx.data_mut(|data| {
+                    data.insert_temp(egui::Id::new("katana_preview_diagram_controls"), false);
+                });
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    let mut section_lifecycle = None;
+                    let mut block_anchors = None;
+                    SectionImageOps::handle_image_section(
+                        ui,
+                        image,
+                        "Mermaid diagram",
+                        0,
+                        1,
+                        0,
+                        None,
+                        Some(states),
+                        None,
+                        &mut section_lifecycle,
+                        &mut block_anchors,
+                        None,
+                        false,
                     );
                 });
             },
@@ -1172,6 +1214,18 @@ mod tests {
         assert!(state.texture.is_some());
         assert_eq!(state.zoom, 1.0);
         assert_eq!(state.pan, egui::Vec2::ZERO);
+    }
+
+    #[test]
+    fn hidden_diagram_controls_retain_texture_for_rendering() {
+        let ctx = egui::Context::default();
+        let image = rasterized_test_image(vec![0, 0, 0, 255]);
+        let mut states = Vec::new();
+
+        render_controls_hidden_rasterized_image(&ctx, &mut states, &image);
+
+        assert_eq!(states.len(), 1);
+        assert!(states[0].texture.is_some());
     }
 
     #[test]


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
KDV 0.5.6 の controls-off preview で図表テクスチャが同一 egui pass 内に破棄され、headless capture で図表が空白になる不具合を修正します。

Closes #339

## 対応内容
- controls の表示可否とテクスチャ保持を分離
- controls-off の図表でも ViewerState に TextureHandle を保持
- KDV 0.5.6 の DocumentFrame 追加フィールドを既定値で初期化
- controls-off 回帰テストを追加

## 動作確認結果
- cargo fmt --check
- clean target で cargo test -p katana-ui --locked preview_pane::tests --lib -- --test-threads=1
  - 82 passed, 1 ignored
- registry candidate KDV 0.5.6 / KRR 0.4.19 で v8 152.2.0 の単一 link を確認